### PR TITLE
doc: Add option for eventing demos to use remote container images

### DIFF
--- a/documentation/modules/ROOT/pages/05eventing/eventing-src-sub.adoc
+++ b/documentation/modules/ROOT/pages/05eventing/eventing-src-sub.adoc
@@ -299,6 +299,11 @@ spec:
 
 <1> Set from `image` parameter --  the fully qualified container image that will be pushed to the registry as part of the build --
 
+[NOTE]
+====
+If you have skipped the xref:ROOT:04build/build.adoc[Build] or xref:ROOT:04build/build-templates.adoc[Build Templates] do not have the container image of `event-greeter`; then you can update the Knative serving service to use the pre-built event-greeter image available at `quay.io/rhdevelopers/knative-tutorial-event-greeter:0.0.1`
+====
+
 [#eventing-deploy-subscriber-service]
 === Deploy Subscriber Service
 

--- a/documentation/modules/ROOT/pages/05eventing/eventing-src-svc.adoc
+++ b/documentation/modules/ROOT/pages/05eventing/eventing-src-svc.adoc
@@ -154,6 +154,11 @@ spec:
 
 <1> Set from `image` parameter --  the fully qualified container image that will be pushed to the registry as part of the build --
 
+[NOTE]
+====
+If you have skipped the xref:ROOT:04build/build.adoc[Build] or xref:ROOT:04build/build-templates.adoc[Build Templates] do not have the container image of `event-greeter`; then you can update the Knative serving service to use the pre-built event-greeter image available at `quay.io/rhdevelopers/knative-tutorial-event-greeter:0.0.1`
+====
+
 [#eventing-deploy-sink-service]
 === Deploy Sink Service
 


### PR DESCRIPTION
If the reader skips the Build chapter then he can use the remote images to complete the eventing chapter

Fixes #30