### PR TITLE
fix: revert remote image url in greeter service

### DIFF
--- a/01-basics/knative/service.yaml
+++ b/01-basics/knative/service.yaml
@@ -8,7 +8,7 @@ spec:
       revisionTemplate:
         spec:
           container:
-            image: quay.io/rhdevelopers/greeter:0.0.1
+            image: dev.local/rhdevelopers/greeter:0.0.1
             livenessProbe:
               httpGet:
                 path: /healthz


### PR DESCRIPTION
The remote service url is pointing to quay.io, reverting inline with instructions