### PR TITLE
Fix location of /target annotation.

### DIFF
--- a/03-scaling/knative/service-10.yaml
+++ b/03-scaling/knative/service-10.yaml
@@ -2,13 +2,14 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: greeter
-  annotations:
-    # Target 10 in-flight-requests per pod.
-    autoscaling.knative.dev/target: "10"
 spec:
   runLatest:
     configuration:
       revisionTemplate:
+        metadata:
+          annotations:
+            # Target 10 in-flight-requests per pod.
+            autoscaling.knative.dev/target: "10"
         spec:
           container:
             image: dev.local/rhdevelopers/greeter:0.0.1

--- a/documentation/modules/ROOT/pages/03scaling.adoc
+++ b/documentation/modules/ROOT/pages/03scaling.adoc
@@ -283,12 +283,13 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: greeter
-  annotations:    
-    autoscaling.knative.dev/target: "10" #<1>
 spec:
   runLatest:
     configuration:
       revisionTemplate:
+        metadata:
+          annotations:
+          autoscaling.knative.dev/target: "10" #<1>
         spec:
           container:
             image: dev.local/rhdevelopers/greeter:0.0.1


### PR DESCRIPTION
Annotations that adjust the way autoscaling works need to be part of the `revisionTemplate`. Making them part of the `Service` will not cause them to be passed down automatically.