### PR TITLE
Various Updates, including some for functionality around knative v0.4.0

### DIFF
--- a/01-basics/knative/service-env.yaml
+++ b/01-basics/knative/service-env.yaml
@@ -2,6 +2,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
   runLatest:
     configuration:

--- a/01-basics/knative/service-pinned-rev1.yaml
+++ b/01-basics/knative/service-pinned-rev1.yaml
@@ -3,8 +3,8 @@ kind: Service
 metadata:
   name: greeter
 spec:
-  pinned:
-    revisionName: greeter-00001
+  release:
+    revisions: ["greeter-00001"]
     configuration:
       revisionTemplate:
         spec:

--- a/01-basics/knative/service-pinned-rev1.yaml
+++ b/01-basics/knative/service-pinned-rev1.yaml
@@ -2,6 +2,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
   release:
     revisions: ["greeter-00001"]

--- a/01-basics/knative/service-pinned-rev2.yaml
+++ b/01-basics/knative/service-pinned-rev2.yaml
@@ -2,9 +2,10 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
-  pinned:
-    revisionName: greeter-00002
+  release:
+    revisions: ["greeter-00002"]
     configuration:
       revisionTemplate:
         spec:

--- a/01-basics/knative/service.yaml
+++ b/01-basics/knative/service.yaml
@@ -2,6 +2,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
   runLatest:
     configuration:

--- a/02-configs-and-routes/config/configuration-rev1.yaml
+++ b/02-configs-and-routes/config/configuration-rev1.yaml
@@ -2,6 +2,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
   revisionTemplate:
     metadata:

--- a/02-configs-and-routes/config/configuration-rev2.yaml
+++ b/02-configs-and-routes/config/configuration-rev2.yaml
@@ -2,6 +2,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
   revisionTemplate:
     metadata:

--- a/02-configs-and-routes/route/route_all_rev1.yaml
+++ b/02-configs-and-routes/route/route_all_rev1.yaml
@@ -2,6 +2,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
   traffic:
     - revisionName: greeter-00001

--- a/02-configs-and-routes/route/route_all_rev2.yaml
+++ b/02-configs-and-routes/route/route_all_rev2.yaml
@@ -2,6 +2,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
   traffic:
     - revisionName: greeter-00002

--- a/02-configs-and-routes/route/route_default.yaml
+++ b/02-configs-and-routes/route/route_default.yaml
@@ -2,6 +2,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
   traffic:
     - configurationName: greeter

--- a/02-configs-and-routes/route/route_rev1-10_rev2-90.yaml
+++ b/02-configs-and-routes/route/route_rev1-10_rev2-90.yaml
@@ -2,6 +2,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
   traffic:
     - revisionName: greeter-00001

--- a/02-configs-and-routes/route/route_rev1-50_rev2-50.yaml
+++ b/02-configs-and-routes/route/route_rev1-50_rev2-50.yaml
@@ -2,6 +2,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
   traffic:
     - revisionName: greeter-00001

--- a/02-configs-and-routes/route/route_rev1-75_rev2-25.yaml
+++ b/02-configs-and-routes/route/route_rev1-75_rev2-25.yaml
@@ -2,6 +2,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
   traffic:
     - revisionName: greeter-00001

--- a/03-scaling/knative/autoscaling-configmap.yaml
+++ b/03-scaling/knative/autoscaling-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-autoscaler
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+data:
+  scale-to-zero-grace-period: 30s
+  stable-window: 60s

--- a/03-scaling/knative/service-10.yaml
+++ b/03-scaling/knative/service-10.yaml
@@ -2,6 +2,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: greeter
+  namespace: knativetutorial
   annotations:
     # Target 10 in-flight-requests per pod.
     autoscaling.knative.dev/target: "10"

--- a/04-build/knative/build-sa.yaml
+++ b/04-build/knative/build-sa.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: build-bot
+  namespace: knativetutorial
 secrets:
   - name: basic-user-pass

--- a/04-build/knative/kaniko-pvc.yaml
+++ b/04-build/knative/kaniko-pvc.yaml
@@ -2,6 +2,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: kaniko-cache
+  namespace: knativetutorial
 spec:
   accessModes:
     - ReadWriteOnce

--- a/04-build/knative/m2-pvc.yaml
+++ b/04-build/knative/m2-pvc.yaml
@@ -2,6 +2,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: m2-cache
+  namespace: knativetutorial
 spec:
   accessModes:
     - ReadWriteOnce

--- a/04-build/knative/templates/docker-build.jsonnet
+++ b/04-build/knative/templates/docker-build.jsonnet
@@ -4,6 +4,7 @@ local lib = import 'library-ext.libjsonnet';
   kind: 'Build',
   metadata: {
     name: 'docker-build',
+    namespace: 'knativetutorial',
   },
   spec: {
     serviceAccountName: 'build-bot',

--- a/04-build/knative/templates/docker-secret.jsonnet
+++ b/04-build/knative/templates/docker-secret.jsonnet
@@ -4,6 +4,7 @@ local lib = import 'library-ext.libjsonnet';
   kind: 'Secret',
   metadata: {
     name: 'basic-user-pass',
+    namespace: 'knativetutorial',
     annotations: {
       'build.knative.dev/docker-0': 'https://index.docker.io/v1/',
     },

--- a/04-build/knative/templates/maven-build-template.jsonnet
+++ b/04-build/knative/templates/maven-build-template.jsonnet
@@ -4,6 +4,7 @@ local lib = import 'library-ext.libjsonnet';
   kind: 'BuildTemplate',
   metadata: {
     name: 'build-java-maven',
+    namespace: 'knativetutorial',
   },
   spec: {
     parameters: [

--- a/04-build/knative/templates/service-with-build-template.jsonnet
+++ b/04-build/knative/templates/service-with-build-template.jsonnet
@@ -5,6 +5,7 @@ local lib = import 'library-ext.libjsonnet';
   kind: 'Service',
   metadata: {
     name: 'event-greeter',
+    namespace: 'knativetutorial',
   },
   spec: {
     runLatest: {

--- a/04-build/knative/templates/service.jsonnet
+++ b/04-build/knative/templates/service.jsonnet
@@ -5,6 +5,7 @@ local lib = import 'library-ext.libjsonnet';
   kind: 'Service',
   metadata: {
     name: 'event-greeter',
+    namespace: 'knativetutorial',
   },
   spec: {
     runLatest: {

--- a/05-eventing/knative/channel-subscriber.yaml
+++ b/05-eventing/knative/channel-subscriber.yaml
@@ -2,6 +2,7 @@ apiVersion: eventing.knative.dev/v1alpha1
 kind: Subscription
 metadata:
   name: event-greeter-subscriber
+  namespace: knativetutorial
 spec:
   channel:
     apiVersion: eventing.knative.dev/v1alpha1

--- a/05-eventing/knative/channel.yaml
+++ b/05-eventing/knative/channel.yaml
@@ -2,6 +2,7 @@ apiVersion: eventing.knative.dev/v1alpha1
 kind: Channel
 metadata:
   name: ch-event-greeter
+  namespace: knativetutorial
 spec:
   provisioner:
     apiVersion: eventing.knative.dev/v1alpha1

--- a/05-eventing/knative/event-source-svc.yaml
+++ b/05-eventing/knative/event-source-svc.yaml
@@ -2,8 +2,9 @@ apiVersion: sources.eventing.knative.dev/v1alpha1
 kind: CronJobSource
 metadata:
   name: event-greeter-cronjob-source
+  namespace: knativetutorial
 spec:
-  schedule: "* * * * *"
+  schedule: "*/1 * * * *"
   data: '{"message": "Thanks for doing Knative Tutorial"}'
   sink:
     apiVersion: serving.knative.dev/v1alpha1

--- a/05-eventing/knative/event-source.yaml
+++ b/05-eventing/knative/event-source.yaml
@@ -2,8 +2,9 @@ apiVersion: sources.eventing.knative.dev/v1alpha1
 kind: CronJobSource
 metadata:
   name: event-greeter-cronjob-source
+  namespace: knativetutorial
 spec:
-  schedule: "* * * * *"
+  schedule: "*/1 * * * *"
   data: '{"message": "Thanks for doing Knative Tutorial"}'
   sink:
     apiVersion: eventing.knative.dev/v1alpha1

--- a/05-eventing/knative/templates/service.jsonnet
+++ b/05-eventing/knative/templates/service.jsonnet
@@ -5,6 +5,7 @@ local lib = import 'library-ext.libjsonnet';
   kind: 'Service',
   metadata: {
     name: 'event-greeter',
+    namespace: 'knativetutorial',
   },
   spec: {
     runLatest: {

--- a/documentation/modules/ROOT/pages/01basic-fundas.adoc
+++ b/documentation/modules/ROOT/pages/01basic-fundas.adoc
@@ -36,6 +36,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
   runLatest: #<1>
     configuration:
@@ -52,14 +53,14 @@ The service could be deployed using the command:
 
 [source,bash,subs="+macros,+attributes"]
 ----
-kubectl apply -n knativetutorial -f link:{github-repo}/{basics-repo}/knative/service.yaml[service.yaml]
+kubectl apply -f link:{github-repo}/{basics-repo}/knative/service.yaml[service.yaml]
 ----
 
 .(OR)
 
 [source,bash,linenums,subs="+macros,+attributes"]
 ----
-oc apply -n knativetutorial -f link:{github-repo}/{basics-repo}/knative/service.yaml[service.yaml]
+oc apply -f link:{github-repo}/{basics-repo}/knative/service.yaml[service.yaml]
 ----
 
 
@@ -135,6 +136,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
   runLatest:
     configuration:
@@ -153,14 +155,14 @@ Let us deploy the new revision using the command:
 
 [source,bash,subs="+macros,+attributes"]
 ----
-kubectl apply -n knativetutorial -f link:{github-repo}/{basics-repo}/knative/service-env.yaml[service-env.yaml]
+kubectl apply -f link:{github-repo}/{basics-repo}/knative/service-env.yaml[service-env.yaml]
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes"]
 ----
-oc apply -n knativetutorial -f link:{github-repo}/{basics-repo}/knative/service-env.yaml[service-env.yaml]
+oc apply -f link:{github-repo}/{basics-repo}/knative/service-env.yaml[service-env.yaml]
 ----
 
 After successful deployment of the service we should see a kubernetes deployment called `greeter-00002-deployment` available in the OpenShift dashboard:
@@ -192,9 +194,10 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
-  pinned: #<1>
-    revisionName: greeter-00001
+  release: #<1>
+    revisions: ["greeter-00001"]
   configuration:
     revisionTemplate:
       spec:
@@ -202,20 +205,20 @@ spec:
           image: dev.local/rhdevelopers/greeter:0.0.1
 ----
 
-<1> The **pinned** attribute in service resource file will make Knative use the revision specified in the **revisionName** attribute.
+<1> The **release** attribute in service resource file will make Knative use the revision specified in the **revisionName** attribute.
 
 Let redeploy the greeter service to be pinned to revision __greeter-00001__:
 
 [source,bash,subs="+macros,+attributes"]
 ----
-kubectl apply -n knativetutorial -f link:{github-repo}/{basics-repo}/knative/service-pinned-rev1.yaml[service-pinned-rev1.yaml]
+kubectl apply -f link:{github-repo}/{basics-repo}/knative/service-pinned-rev1.yaml[service-pinned-rev1.yaml]
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes"]
 ----
-oc apply -n knativetutorial -f link:{github-repo}/{basics-repo}/knative/service-pinned-rev1.yaml[service-pinned-rev1.yaml]
+oc apply -f link:{github-repo}/{basics-repo}/knative/service-pinned-rev1.yaml[service-pinned-rev1.yaml]
 ----
 
 <<basics-invoke-service,Invoking Service>> will now show an output like **Hi greeter => greeter-00001-deployment-5d696cc6c8-m65s5: 3**.

--- a/documentation/modules/ROOT/pages/02configs-and-routes.adoc
+++ b/documentation/modules/ROOT/pages/02configs-and-routes.adoc
@@ -38,6 +38,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
   revisionTemplate:
     metadata:
@@ -53,14 +54,14 @@ spec:
 The service is then deployed using:
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-kubectl apply -n knativetutorial -f link:{github-repo}/{configs-and-routes-repo}/config/configuration-rev1.yaml[config/configuration-rev1.yaml]
+kubectl apply -f link:{github-repo}/{configs-and-routes-repo}/config/configuration-rev1.yaml[config/configuration-rev1.yaml]
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-oc apply -n knativetutorial -f link:{github-repo}/{configs-and-routes-repo}/config/configuration-rev1.yaml[config/configuration-rev1.yaml]
+oc apply -f link:{github-repo}/{configs-and-routes-repo}/config/configuration-rev1.yaml[config/configuration-rev1.yaml]
 ----
 
 After the deployment was successful, we should see a kubernetes deployment called `greeter-00001-deployment`.
@@ -93,6 +94,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: greeter
+  namespace: knativetutorial  
 spec:
   traffic:
     - configurationName: greeter
@@ -101,14 +103,14 @@ spec:
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-kubectl apply -n knativetutorial -f link:{github-repo}/{configs-and-routes-repo}/route/route_default.yaml[route/route_default.yaml]
+kubectl apply -f link:{github-repo}/{configs-and-routes-repo}/route/route_default.yaml[route/route_default.yaml]
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-oc apply -n knativetutorial -f link:{github-repo}/{configs-and-routes-repo}/route/route_default.yaml[route/route_default.yaml]
+oc apply -f link:{github-repo}/{configs-and-routes-repo}/route/route_default.yaml[route/route_default.yaml]
 ----
 
 <<invoke-service,Invoking Service>> now should return a response like **Hi greeter => greeter-00001-deployment-5d696cc6c8-m65s5: 1**
@@ -164,6 +166,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: greeter
+  namespace: knativetutorial
 spec:
   revisionTemplate:
     metadata:
@@ -183,14 +186,14 @@ Let us deploy the new revision using the command:
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-kubectl apply -n knativetutorial -f  link:{github-repo}/{configs-and-routes-repo}/config/configuration-rev2.yaml[config/configuration-rev2.yaml]
+kubectl apply -f  link:{github-repo}/{configs-and-routes-repo}/config/configuration-rev2.yaml[config/configuration-rev2.yaml]
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-oc apply -n knativetutorial -f  link:{github-repo}/{configs-and-routes-repo}/config/configuration-rev2.yaml[config/configuration-rev2.yaml]
+oc apply -f  link:{github-repo}/{configs-and-routes-repo}/config/configuration-rev2.yaml[config/configuration-rev2.yaml]
 ----
 
 After the deployment was successful we should see a kubernetes deployment called `greeter-00002-deployment` in the OpenShift dashboard:
@@ -218,14 +221,14 @@ Before we start to apply routes, let us open a new terminal and run the followin
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-kubectl apply -n knativetutorial -f  link:{github-repo}/{configs-and-routes-repo}/route/route_all_rev1.yaml[route/route_all_rev1.yaml]
+kubectl apply -f  link:{github-repo}/{configs-and-routes-repo}/route/route_all_rev1.yaml[route/route_all_rev1.yaml]
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-oc apply -n knativetutorial -f  link:{github-repo}/{configs-and-routes-repo}/route/route_all_rev1.yaml[route/route_all_rev1.yaml]
+oc apply -f  link:{github-repo}/{configs-and-routes-repo}/route/route_all_rev1.yaml[route/route_all_rev1.yaml]
 ----
 
 You will notice the output on your monitoring terminal to be something like **Hi greeter => greeter-00001-deployment-5d696cc6c8-m65s5: 34**.
@@ -235,14 +238,14 @@ You will notice the output on your monitoring terminal to be something like **Hi
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-kubectl apply -n knativetutorial -f link:{github-repo}/{configs-and-routes-repo}/route/route_all_rev2.yaml[route/route_all_rev2.yaml]
+kubectl apply -f link:{github-repo}/{configs-and-routes-repo}/route/route_all_rev2.yaml[route/route_all_rev2.yaml]
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-oc apply -n knativetutorial -f link:{github-repo}/{configs-and-routes-repo}/route/route_all_rev2.yaml[route/route_all_rev2.yaml]
+oc apply -f link:{github-repo}/{configs-and-routes-repo}/route/route_all_rev2.yaml[route/route_all_rev2.yaml]
 ----
 
 You will notice the output on your monitoring terminal to be something like **Namaste greeter => greeter-00002-deployment-8d9984dc8-rgzx6: 13**.
@@ -252,14 +255,14 @@ You will notice the output on your monitoring terminal to be something like **Na
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-kubectl apply -n knativetutorial -f link:{github-repo}/{configs-and-routes-repo}/route/route_rev1-50_rev2-50.yaml[route/route_rev1-50_rev2-50.yaml]
+kubectl apply -f link:{github-repo}/{configs-and-routes-repo}/route/route_rev1-50_rev2-50.yaml[route/route_rev1-50_rev2-50.yaml]
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-oc apply -n knativetutorial -f link:{github-repo}/{configs-and-routes-repo}/route/route_rev1-50_rev2-50.yaml[route/route_rev1-50_rev2-50.yaml]
+oc apply -f link:{github-repo}/{configs-and-routes-repo}/route/route_rev1-50_rev2-50.yaml[route/route_rev1-50_rev2-50.yaml]
 ----
 
 You will notice the output will be mix of responses like **Hi greeter => greeter-00001-deployment-5d696cc6c8-m65s5: 11** and **Namaste greeter => greeter-00002-deployment-8d9984dc8-rgzx6: 10** approximately distributed 50% between the two.
@@ -269,14 +272,14 @@ You will notice the output will be mix of responses like **Hi greeter => greeter
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-kubectl apply -n knativetutorial -f link:{github-repo}/{configs-and-routes-repo}/route/route_rev1-75_rev2-25.yaml[route/route_rev1-75_rev2-25.yaml]
+kubectl apply -f link:{github-repo}/{configs-and-routes-repo}/route/route_rev1-75_rev2-25.yaml[route/route_rev1-75_rev2-25.yaml]
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-oc apply -n knativetutorial -f link:{github-repo}/{configs-and-routes-repo}/route/route_rev1-75_rev2-25.yaml[route/route_rev1-75_rev2-25.yaml]
+oc apply -f link:{github-repo}/{configs-and-routes-repo}/route/route_rev1-75_rev2-25.yaml[route/route_rev1-75_rev2-25.yaml]
 ----
 
 You will notice the output will be mix of responses like **Hi greeter => greeter-00001-deployment-5d696cc6c8-m65s5: 6** and **Namaste greeter => greeter-00002-deployment-8d9984dc8-rgzx6: 7**, with more requests responded by revision  1 approximately distributed 75% to 25 % between revision 1 and revision 2.
@@ -286,14 +289,14 @@ You will notice the output will be mix of responses like **Hi greeter => greeter
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-kubectl apply -n knativetutorial -f link:{github-repo}/{configs-and-routes-repo}/route/route_rev1-10_rev2-90.yaml[route/route_rev1-10_rev2-90.yaml]
+kubectl apply -f link:{github-repo}/{configs-and-routes-repo}/route/route_rev1-10_rev2-90.yaml[route/route_rev1-10_rev2-90.yaml]
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-oc apply -n knativetutorial -f link:{github-repo}/{configs-and-routes-repo}/route/route_rev1-10_rev2-90.yaml[route/route_rev1-10_rev2-90.yaml]
+oc apply -f link:{github-repo}/{configs-and-routes-repo}/route/route_rev1-10_rev2-90.yaml[route/route_rev1-10_rev2-90.yaml]
 ----
 
 You will notice the will be mix of responses like **Hi greeter => greeter-00001-deployment-5d696cc6c8-m65s5: 4** and **Namaste greeter => greeter-00002-deployment-8d9984dc8-rgzx6: 5**, with more requests responded by revision 2 approximately 10% to 90% between revision 1 and revision 2.

--- a/documentation/modules/ROOT/pages/03scaling.adoc
+++ b/documentation/modules/ROOT/pages/03scaling.adoc
@@ -18,6 +18,48 @@ include::partial$prereq-cli.adoc[]
 == Build Containers
 include::partial$build-containers.adoc[tag=greeter]
 
+[#scaling-modify-configmap]
+== Setting Configmap Defaults
+
+Knative v0.4.0 changed how the default configuration map values are set and provided.
+For the purposes of this section, lets apply a few defaults.
+
+[.text-center]
+.link:{github-repo}/{scaling-repo}/knative/autoscaling-configmap.yaml[autoscaling-configmap.yaml]
+[source,yaml,linenums]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-autoscaler
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+data:
+  scale-to-zero-grace-period: 30s
+  stable-window: 60s
+----
+Navigate to the tutorial chapter's `Knative` folder:
+
+[source,bash,subs="+macros,+attributes"]
+----
+cd $TUTORIAL_HOME/03-serving/knative
+----
+
+The service can be deployed using the command:
+
+[source,bash,subs="+macros,+attributes"]
+----
+kubectl apply -f link:{github-repo}/{serving-repo}/knative/autoscaling-configmap.yaml[autoscaling-configmap.yaml]
+----
+
+.(OR)
+
+[source,bash,subs="+macros,+attributes"]
+----
+oc apply -f link:{github-repo}/{serving-repo}/knative/autoscaling-configmap.yaml[autoscaling-configmap.yaml]
+----
+
 [#scaling-deploy-service]
 == Deploy Service
 
@@ -343,7 +385,7 @@ We will now send some load to the greeter service.  The command below sends 50 c
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-seige -r 1 -c 50 -t 30S -d 2 \
+siege -r 1 -c 50 -t 30S -d 2 \
   -H "Host: greeter.knativetutorial.example.com" \
   "http://pass:[${IP_ADDRESS}]"
 ----

--- a/documentation/modules/ROOT/pages/04build/build-templates.adoc
+++ b/documentation/modules/ROOT/pages/04build/build-templates.adoc
@@ -179,14 +179,14 @@ cd $TUTORIAL_HOME/04-build/knative
 
 [source,bash,subs="+macros,+attributes"]
 ----
-kubectl apply -n knativetutorial -f maven-build-template.yaml
+kubectl apply -f maven-build-template.yaml
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes"]
 ----
-oc apply -n knativetutorial -f maven-build-template.yaml
+oc apply -f maven-build-template.yaml
 ----
 
 [#build-see-what-you-have-deployed]
@@ -205,14 +205,14 @@ Run the following commands to deploy the service:
 
 [source,bash,subs="+macros,+attributes"]
 ----
-kubectl apply -n knativetutorial -f service-with-build-template.yaml
+kubectl apply -f service-with-build-template.yaml
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes"]
 ----
-oc apply -n knativetutorial -f service-with-build-template.yaml
+oc apply -f service-with-build-template.yaml
 ----
 
 

--- a/documentation/modules/ROOT/pages/04build/build.adoc
+++ b/documentation/modules/ROOT/pages/04build/build.adoc
@@ -205,20 +205,20 @@ Run the following commands to create the pre-requisite resources:
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-kubectl apply -n knativetutorial -f docker-secret.yaml
-kubectl apply -n knativetutorial -f link:{github-repo}/{build-repo}/knative/build-sa.yaml[build-sa.yaml]
-kubectl apply -n knativetutorial -f link:{github-repo}/{build-repo}/knative/m2-pvc.yaml[m2-pvc.yaml]
-kubectl apply -n knativetutorial -f link:{github-repo}/{build-repo}/knative/kaniko-pvc.yaml[kaniko-pvc.yaml]
+kubectl apply -f docker-secret.yaml
+kubectl apply -f link:{github-repo}/{build-repo}/knative/build-sa.yaml[build-sa.yaml]
+kubectl apply -f link:{github-repo}/{build-repo}/knative/m2-pvc.yaml[m2-pvc.yaml]
+kubectl apply -f link:{github-repo}/{build-repo}/knative/kaniko-pvc.yaml[kaniko-pvc.yaml]
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-oc apply -n knativetutorial -f docker-secret.yaml <1>
-oc apply -n knativetutorial -f link:{github-repo}/{build-repo}/knative/build-sa.yaml[build-sa.yaml] <2>
-oc apply -n knativetutorial -f link:{github-repo}/{build-repo}/knative/m2-pvc.yaml[m2-pvc.yaml] <3>
-oc apply -n knativetutorial -f link:{github-repo}/{build-repo}/knative/kaniko-pvc.yaml[kaniko-pvc.yaml] <4>
+oc apply -f docker-secret.yaml <1>
+oc apply -f link:{github-repo}/{build-repo}/knative/build-sa.yaml[build-sa.yaml] <2>
+oc apply -f link:{github-repo}/{build-repo}/knative/m2-pvc.yaml[m2-pvc.yaml] <3>
+oc apply -f link:{github-repo}/{build-repo}/knative/kaniko-pvc.yaml[kaniko-pvc.yaml] <4>
 ----
 
 
@@ -232,14 +232,14 @@ oc apply -n knativetutorial -f link:{github-repo}/{build-repo}/knative/kaniko-pv
 
 [source,bash,subs="+macros,+attributes"]
 ----
-kubectl apply -n knativetutorial -f docker-build.yaml
+kubectl apply -f docker-build.yaml
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes"]
 ----
-oc apply -n knativetutorial -f docker-build.yaml
+oc apply -f docker-build.yaml
 ----
 
 [#build-see-what-you-have-deployed]
@@ -256,16 +256,16 @@ The builds right now can't be started from the step where it has failed, you alw
 e.g. 
 [source,bash,subs="+macros,+attributes"]
 ----
-kubectl delete -n knativetutorial -f docker-build.yaml
-kubectl apply -n knativetutorial -f docker-build.yaml
+kubectl delete -f docker-build.yaml
+kubectl apply -f docker-build.yaml
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes"]
 ----
-oc delete -n knativetutorial -f docker-build.yaml
-oc apply -n knativetutorial -f docker-build.yaml
+oc delete -f docker-build.yaml
+oc apply -f docker-build.yaml
 ----
 ====
 
@@ -309,14 +309,14 @@ With a successful build you are ready to deploy the service, run the following c
 
 [source,bash,subs="+macros,+attributes"]
 ----
-kubectl apply -n knativetutorial -f service-build.yaml
+kubectl apply -f service-build.yaml
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes"]
 ----
-oc apply -n knativetutorial -f service-build.yaml
+oc apply -f service-build.yaml
 ----
 
 After successful deployment of the service we should see a kubernetes deployment called `event-greeter-00001-deployment` available in the OpenShift dashboard:

--- a/documentation/modules/ROOT/pages/05eventing/eventing-src-sub.adoc
+++ b/documentation/modules/ROOT/pages/05eventing/eventing-src-sub.adoc
@@ -15,6 +15,7 @@ apiVersion: eventing.knative.dev/v1alpha1
 kind: Channel
 metadata:
   name: ch-event-greeter #<1>
+  namespace: knativetutorial
 spec:
   provisioner: #<2>
     apiVersion: eventing.knative.dev/v1alpha1
@@ -36,14 +37,14 @@ Run the following commands to create the channel:
 
 [source,bash,subs="+macros,+attributes"]
 ----
-kubectl apply -n knativetutorial -f link:{github-repo}/{eventing-repo}/knative/channel.yaml[channel.yaml]
+kubectl apply -f link:{github-repo}/{eventing-repo}/knative/channel.yaml[channel.yaml]
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes"]
 ----
-oc apply -n knativetutorial -f link:{github-repo}/{eventing-repo}/knative/channel.yaml[channel.yaml]
+oc apply -f link:{github-repo}/{eventing-repo}/knative/channel.yaml[channel.yaml]
 ----
 
 [#eventing-verify-event-channel]
@@ -84,8 +85,9 @@ apiVersion: sources.eventing.knative.dev/v1alpha1
 kind: CronJobSource #<1>
 metadata:
   name: event-greeter-cronjob-source
+  namespace: knativetutorial
 spec:
-  schedule: "* * * * *"
+  schedule: "*/1 * * * *"
   data: '{"message": "Thanks for doing the Knative Tutorial"}'
   sink: 
     apiVersion: eventing.knative.dev/v1alpha1
@@ -108,14 +110,14 @@ Run the following commands to create the event source resources:
 
 [source,bash,subs="+macros,+attributes"]
 ----
-kubectl apply -n knativetutorial -f link:{github-repo}/{eventing-repo}/knative/event-source.yaml[event-source.yaml]
+kubectl apply -f link:{github-repo}/{eventing-repo}/knative/event-source.yaml[event-source.yaml]
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes"]
 ----
-oc apply -n knativetutorial -f link:{github-repo}/{eventing-repo}/knative/event-source.yaml[event-source.yaml] 
+oc apply -f link:{github-repo}/{eventing-repo}/knative/event-source.yaml[event-source.yaml] 
 ----
 
 [#eventing-verify-event-source]
@@ -178,7 +180,7 @@ apiVersion: eventing.knative.dev/v1alpha1
 kind: Subscription
 metadata:
   name: event-greeter-subscriber #<1>
-  namespace: default
+  namespace: knativetutorial
 spec:
   channel:
     apiVersion: eventing.knative.dev/v1alpha1
@@ -285,6 +287,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: event-greeter
+  namespace: knativetutorial
 spec:
   runLatest:
     configuration:
@@ -318,14 +321,14 @@ Run the following commands to create the service:
 
 [source,bash,subs="+macros,+attributes"]
 ----
-kubectl apply -n knativetutorial -f service.yaml 
+kubectl apply -f service.yaml 
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes"]
 ----
-oc apply -n knativetutorial -f service.yaml 
+oc apply -f service.yaml 
 ----
 
 You can xref:05eventing/eventing.adoc#eventing-watch-logs[watch logs] to see the cron job source sending an event every 1 minute.

--- a/documentation/modules/ROOT/pages/05eventing/eventing-src-svc.adoc
+++ b/documentation/modules/ROOT/pages/05eventing/eventing-src-svc.adoc
@@ -1,6 +1,100 @@
 = Eventing Source to Service
 include::_attributes.adoc[]
 
+[#eventing-sink-service]
+== Create Sink Service 
+
+[#eventing-gen-sink-service]
+=== Generate Sink Service
+
+Navigate to tutorial chapter's `templates` folder:
+
+[source,bash,subs="+macros,+attributes"]
+----
+cd $TUTORIAL_HOME/05-eventing/knative/templates
+----
+
+Run the following command to create the knative service that will be used as the subscriber for the cron events:
+
+[source,bash,subs="+macros,+attributes",linenums]
+----
+
+jsonnet --ext-str image='<your-docker-image-name>' \
+   link:{github-repo}/{eventing-repo}/knative/templates/service.jsonnet[service.jsonnet]\
+   | yq r - | tee ../service.yaml
+----
+
+(e.g)
+[source,bash,subs="+macros,+attributes",linenums]
+----
+jsonnet --ext-str image='docker.io/demo/event-greeter:0.0.1' \
+   link:{github-repo}/{eventing-repo}/knative/templates/service.jsonnet[service.jsonnet] \
+    | yq r - | tee ../service.yaml
+----
+
+[.text-center]
+.service.yaml
+[source,yaml,linenums]
+----
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: event-greeter
+  namespace: knativetutorial
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        metadata:
+          labels:
+            app: event-greeter
+        spec:
+          container:
+            image: docker.io/demo/event-greeter:0.0.1 <1>
+----
+
+<1> Set from `image` parameter --  the fully qualified container image that will be pushed to the registry as part of the build --
+
+[NOTE]
+====
+If you have skipped the xref:ROOT:04build/build.adoc[Build] or xref:ROOT:04build/build-templates.adoc[Build Templates] do not have the container image of `event-greeter`; then you can update the Knative serving service to use the pre-built event-greeter image available at `quay.io/rhdevelopers/knative-tutorial-event-greeter:0.0.1`
+====
+
+[#eventing-deploy-sink-service]
+=== Deploy Sink Service
+
+Navigate to tutorial chapter's `knative` folder:
+
+[source,bash,subs="+macros,+attributes"]
+----
+cd $TUTORIAL_HOME/05-eventing/knative
+----
+
+Run the following commands to create the service:
+
+[source,bash,subs="+macros,+attributes"]
+----
+kubectl apply -f service.yaml
+----
+
+.(OR)
+
+[source,bash,subs="+macros,+attributes"]
+----
+oc apply -f service.yaml
+----
+
+You can xref:05eventing/eventing.adoc#eventing-watch-logs[watch logs] to see the cron job source sending an event every 1 minute.
+
+[#eventing-see-what-you-have-deployed]
+=== See what you have deployed
+
+==== sources
+include::partial$knative-objects.adoc[tag=knative-event-cronjob-sources]
+
+==== services
+include::partial$knative-objects.adoc[tag=knative-event-services]
+
 [#eventing-source]
 == Event Source
 
@@ -23,10 +117,11 @@ apiVersion: sources.eventing.knative.dev/v1alpha1
 kind: CronJobSource #<1>
 metadata:
   name: event-greeter-cronjob-source
+  namespace: knativetutorial
 spec:
-  schedule: "* * * * *"
+  schedule: "*/1 * * * *"
   data: '{"message": "Thanks for doing the Knative Tutorial"}'
-  sink: 
+  sink:
     apiVersion: serving.knative.dev/v1alpha1
     kind: Service
     name: event-greeter #<2>
@@ -37,7 +132,7 @@ spec:
 
 [NOTE]
 ====
-Event Source can define the attributes that it wishes to receive via the 
+Event Source can define the attributes that it wishes to receive via the
 spec.  In the above example it defines **schedule**(the the cron expression) and **data** that will be sent as part of the event.
 
 When you xref:05eventing/eventing.adoc#eventing-watch-logs[watch logs], you will notice this data being delivered to the service.
@@ -47,14 +142,14 @@ Run the following commands to create the event source resources:
 
 [source,bash,subs="+macros,+attributes"]
 ----
-kubectl apply -n knativetutorial -f link:{github-repo}/{eventing-repo}/knative/event-source-svc.yaml[event-source-svc.yaml]
+kubectl apply -f link:{github-repo}/{eventing-repo}/knative/event-source-svc.yaml[event-source-svc.yaml]
 ----
 
 .(OR)
 
 [source,bash,subs="+macros,+attributes"]
 ----
-oc apply -n knativetutorial -f link:{github-repo}/{eventing-repo}/knative/event-source-svc.yaml[event-source-svc.yaml] 
+oc apply -f link:{github-repo}/{eventing-repo}/knative/event-source-svc.yaml[event-source-svc.yaml] 
 ----
 
 [#eventing-verify-event-source]
@@ -100,99 +195,6 @@ The above command will return an output like,
 NAME                                                          READY     STATUS    RESTARTS   AGE
 cronjob-event-greeter-cronjob-source-4v9vq-6bff96b58f-tgrhj   2/2       Running   0          6m
 ----
-
-[#eventing-sink-service]
-== Create Sink Service 
-
-[#eventing-gen-sink-service]
-=== Generate Sink Service
-
-Navigate to tutorial chapter's `templates` folder:
-
-[source,bash,subs="+macros,+attributes"]
-----
-cd $TUTORIAL_HOME/05-eventing/knative/templates
-----
-
-Run the following command to create the knative service that will be used as the subscriber for the cron events:
-
-[source,bash,subs="+macros,+attributes",linenums]
-----
-
-jsonnet --ext-str image='<your-docker-image-name>' \
-   link:{github-repo}/{eventing-repo}/knative/templates/service.jsonnet[service.jsonnet]\
-   | yq r - | tee ../service.yaml
-----
-
-(e.g)
-[source,bash,subs="+macros,+attributes",linenums]
-----
-jsonnet --ext-str image='docker.io/demo/event-greeter:0.0.1' \
-   link:{github-repo}/{eventing-repo}/knative/templates/service.jsonnet[service.jsonnet] \
-    | yq r - | tee ../service.yaml
-----
-
-[.text-center]
-.service.yaml
-[source,yaml,linenums]
-----
-apiVersion: serving.knative.dev/v1alpha1
-kind: Service
-metadata:
-  name: event-greeter
-spec:
-  runLatest:
-    configuration:
-      revisionTemplate:
-        metadata:
-          labels:
-            app: event-greeter
-        spec:
-          container:
-            image: docker.io/demo/event-greeter:0.0.1 <1>
-----
-
-<1> Set from `image` parameter --  the fully qualified container image that will be pushed to the registry as part of the build --
-
-[NOTE]
-====
-If you have skipped the xref:ROOT:04build/build.adoc[Build] or xref:ROOT:04build/build-templates.adoc[Build Templates] do not have the container image of `event-greeter`; then you can update the Knative serving service to use the pre-built event-greeter image available at `quay.io/rhdevelopers/knative-tutorial-event-greeter:0.0.1`
-====
-
-[#eventing-deploy-sink-service]
-=== Deploy Sink Service
-
-Navigate to tutorial chapter's `knative` folder:
-
-[source,bash,subs="+macros,+attributes"]
-----
-cd $TUTORIAL_HOME/05-eventing/knative
-----
-
-Run the following commands to create the service:
-
-[source,bash,subs="+macros,+attributes"]
-----
-kubectl apply -n knativetutorial -f service.yaml 
-----
-
-.(OR)
-
-[source,bash,subs="+macros,+attributes"]
-----
-oc apply -n knativetutorial -f service.yaml 
-----
-
-You can xref:05eventing/eventing.adoc#eventing-watch-logs[watch logs] to see the cron job source sending an event every 1 minute.
-
-[#eventing-see-what-you-have-deployed]
-=== See what you have deployed
-
-==== sources
-include::partial$knative-objects.adoc[tag=knative-event-cronjob-sources]
-
-==== services
-include::partial$knative-objects.adoc[tag=knative-event-services]
 
 [#eventing-cleanup]
 == Cleanup

--- a/documentation/modules/ROOT/pages/setup.adoc
+++ b/documentation/modules/ROOT/pages/setup.adoc
@@ -81,8 +81,8 @@ The `work` folder in `$TUTORIAL_HOME` can be used to download the demo applicati
 
 This tutorial was developed and tested with:
 
-- Knative `v0.3.0`
-- minikube `v0.34.1`
+- Knative `v0.4.0`
+- minikube `v0.35.0`
 - OpenShift `v3.11`
 - minishift `v1.30.0+186b034`
 ====
@@ -105,8 +105,7 @@ minikube profile knative \#<1>
 minikube start -p knative --memory=8192 --cpus=4 \#<2> 
   --kubernetes-version=v1.12.0 \#<3> 
   --vm-driver=hyperkit \#<4>  
-  --disk-size=50g \
-  --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
+  --disk-size=50g"
 ----
 
 <1> Setting minikube profile to **knative** so that all future minikube commands are executed with this profile context
@@ -216,7 +215,6 @@ build-webhook-6bb747665f-trjxg      1/1     Running   0          6h32m
 [source,bash,subs="+macros,+attributes"]
 ----
 kubectl apply --filename {knative-eventing-repo}/{knative-version}/release.yaml
-kubectl apply --filename {knative-eventing-repo}/{knative-version}/in-memory-channel.yaml
 kubectl apply --filename {knative-sources-repo}/{knative-version}/release.yaml
 ----
 


### PR DESCRIPTION
Hi, please see the commits to help get things working on knative v0.4.0

This includes fixing the autoscaling section by adjusting our first definition of the autoscale-configmap so that the rest of the section and proceed unbroken (v0.4.0 moves the previously existing variables into a comment).

We also have moved from the (deprecated) 'pinned.revisionName' versioning to 'release.revisions' moving forward.

One aspect this does not fix, is how deployment names are now unordered and randomly generated.