### PR TITLE
(release): tag documentation v1.0.0

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -1,6 +1,6 @@
 name: knative-tutorial
 title: Knative Tutorial
-version: 1.0-SNAPSHOT
+version: v1.0.0
 nav:
   - modules/ROOT/nav.adoc
   - modules/camelk/nav.adoc


### PR DESCRIPTION
First release of the tutorial which is compatible with Knative v0.3.0. 