### PR TITLE
(site): Prepare for v0.4.0 upgrade

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -1,6 +1,6 @@
 name: knative-tutorial
 title: Knative Tutorial
-version: v1.0.0
+version: v1.1.0-SNAPSHOT
 nav:
   - modules/ROOT/nav.adoc
   - modules/camelk/nav.adoc

--- a/site.yml
+++ b/site.yml
@@ -4,12 +4,13 @@ runtime:
 site:
   title: Knative Tutorial
   url: https://redhat-developer-demos.github.io/knative-tutorial
-  start_page: knative-tutorial::index.adoc
+  start_page: v1.0.0@knative-tutorial::index.adoc
 
 content:
   sources:
     - url: .
-      branches: HEAD
+      tags: v*
+      branches: master
       start_path: documentation
 ui:
   bundle:


### PR DESCRIPTION
 - Prepare for v0.4.0 upgrade
- Pin the documentation default to previous release `v1.0.0`