### PR TITLE
Update basics chapter for knative v0.4.0

### DIFF
--- a/01-basics/knative/service-pinned-rev1.yaml
+++ b/01-basics/knative/service-pinned-rev1.yaml
@@ -3,8 +3,8 @@ kind: Service
 metadata:
   name: greeter
 spec:
-  pinned:
-    revisionName: greeter-00001
+  release:
+    revisions: ["greeter-00001"]
     configuration:
       revisionTemplate:
         spec:

--- a/01-basics/knative/service-pinned-rev2.yaml
+++ b/01-basics/knative/service-pinned-rev2.yaml
@@ -3,8 +3,8 @@ kind: Service
 metadata:
   name: greeter
 spec:
-  pinned:
-    revisionName: greeter-00002
+  release:
+    revisions: ["greeter-00002"]
     configuration:
       revisionTemplate:
         spec:

--- a/documentation/modules/ROOT/pages/02-basic-fundas.adoc
+++ b/documentation/modules/ROOT/pages/02-basic-fundas.adoc
@@ -193,8 +193,8 @@ kind: Service
 metadata:
   name: greeter
 spec:
-  pinned: #<1>
-    revisionName: greeter-00001
+  release: #<1>
+    revisions: ["greeter-00001"]
   configuration:
     revisionTemplate:
       spec:
@@ -202,7 +202,7 @@ spec:
           image: dev.local/rhdevelopers/greeter:0.0.1
 ----
 
-<1> The **pinned** attribute in service resource file will make Knative use the revision specified in the **revisionName** attribute.
+<1> The **release** attribute in service resource file will make Knative use the revision specified in the **revisions** attribute.
 
 Let redeploy the greeter service to be pinned to revision __greeter-00001__:
 


### PR DESCRIPTION
The serving 'pinned' keyword is being deprecated, so move over to
using 'release' and  'revisions' for forward compat.