### PR TITLE
Fix chapter 3 for knative v0.4.0

### DIFF
--- a/04-scaling/knative/autoscaling-configmap.yaml
+++ b/04-scaling/knative/autoscaling-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-autoscaler
+  labels:
+    serving.knative.dev/release: devel
+data:
+  scale-to-zero-grace-period: 30s
+  stable-window: 60s

--- a/documentation/modules/ROOT/pages/04-scaling.adoc
+++ b/documentation/modules/ROOT/pages/04-scaling.adoc
@@ -18,6 +18,47 @@ include::partial$prereq-cli.adoc[]
 == Build Containers
 include::partial$build-containers.adoc[tag=greeter]
 
+[#scaling-modify-configmap]
+== Setting Configmap Defaults
+
+Knative v0.4.0 changed how the default configuration map values are set and provided.
+For the purposes of this section, lets apply a few defaults.
+
+[.text-center]
+.link:{github-repo}/{scaling-repo}/knative/autoscaling-configmap.yaml[autoscaling-configmap.yaml]
+[source,yaml,linenums]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-autoscaler
+  labels:
+    serving.knative.dev/release: devel
+data:
+  scale-to-zero-grace-period: 30s
+  stable-window: 60s
+----
+Navigate to the tutorial chapter's `Knative` folder:
+
+[source,bash,subs="+macros,+attributes"]
+----
+cd $TUTORIAL_HOME/03-serving/knative
+----
+
+The service can be deployed using the command:
+
+[source,bash,subs="+macros,+attributes"]
+----
+kubectl apply -n knative-serving -f link:{github-repo}/{serving-repo}/knative/autoscaling-configmap.yaml[autoscaling-configmap.yaml]
+----
+
+.(OR)
+
+[source,bash,subs="+macros,+attributes"]
+----
+oc apply -n knative-serving -f link:{github-repo}/{serving-repo}/knative/autoscaling-configmap.yaml[autoscaling-configmap.yaml]
+----
+
 [#scaling-deploy-service]
 == Deploy Service
 


### PR DESCRIPTION
Our previous approach for editing the configmap broke because the
autoscaler configmap went from defining the defaults to providing
examples in the configmap on variables to change.

To get around this and keep the changes around this section minimal,
we've added a small configmap to apply that will set this defaults
explicitly.  The remainder of the section (with yq invocations) will
work as advertised.