### PR TITLE
Revert gulpfile.js to work with gulp 3.9.1, update README-DEV to use …

### DIFF
--- a/README-DEV.adoc
+++ b/README-DEV.adoc
@@ -7,7 +7,7 @@ You can preview changes as you make them as follows:
 1. Install the `antora` website generator and `gulp` build system
 +
 ....
-npm install -g @antora/cli @antora/site-generator-default gulp gulp-connect gulp-open yaml-js
+npm install -g @antora/cli @antora/site-generator-default gulp@^3.9.1 gulp-connect yaml-js
 ....
 
 2. Create a `dev-site.yml` file (the `site.yml` file is for the public website)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,13 +4,12 @@ const connect = require("gulp-connect");
 const fs = require("fs");
 const generator = require("@antora/site-generator-default");
 const gulp = require("gulp");
-const open = require("gulp-open");
 const yaml = require("yaml-js");
 
 let filename = "dev-site.yml";
 let args = ["--playbook", filename];
 
-function build(cb) {
+gulp.task("build", function(cb) {
   /**
    * Use the '@antora/site-generator-default' node module to build.
    * It's analogous to `$ antora --playbook local-antora-playbook.yml`.
@@ -20,36 +19,44 @@ function build(cb) {
    * a separate process for each run. So if a build error occurs with the `gulp`
    * command it can be useful to check if it also happens with the CLI command.
    */
-  generator(args, process.env).catch(err => { console.log(err); })
-  connect.reload()
-  cb();
-}
+  generator(args, process.env)
+    .then(() => {
+      cb();
+    })
+    .catch(err => {
+      console.log(err);
+      cb();
+    });
+});
 
-function watch() {
+gulp.task("preview", ["build"], function() {
+  /**
+   * Remove the line gulp.src('README.adoc')
+   * This is placeholder code to follow the gulp-connect
+   * example. Could not make it work any other way.
+   */
+  gulp.src("README.adoc").pipe(connect.reload());
+});
+
+gulp.task("watch", function() {
   let json_content = fs.readFileSync(`${__dirname}/${filename}`, "UTF-8");
   let yaml_content = yaml.load(json_content);
-  let sources = yaml_content.content.sources.map(source => [
-    `${source.url}/**/*.yml`,
-    `${source.url}/**/*.adoc`,
+  let dirs = yaml_content.content.sources.map(source => [
+    `${source.url}/**/**.yml`,
+    `${source.url}/**/**.adoc`,
     `${source.url}/**/**.hbs`
   ]);
-  sources.push(["dev-site.yml"]);
-  sources = [].concat.apply([], sources) // Flatten the array
-  gulp.watch(sources, build)
-}
+  dirs.push(["dev-site.yml"]);
+  gulp.watch(dirs, ["preview"]);
+});
 
-function serve() {
+gulp.task("connect", function() {
   connect.server({
     port: 5353,
     name: "Dev Server",
     livereload: true,
     root: "gh-pages"
   });
-}
+});
 
-function browse() {
-  gulp.src("gh-pages/index.html").pipe(open({uri: 'http://localhost:5353'}))
-}
-
-exports.build = build;
-exports.default = gulp.parallel(serve, watch, browse)
+gulp.task("default", ["connect", "watch", "build"]);


### PR DESCRIPTION
…that version.

Revert "Merge pull request #108 from alanconway/readme-dev"

This reverts commit 62b64030ba2d22d23ab749b94d93a1e94e0843bd, reversing
changes made to 2459547b52e0d4be37b67812c55d82e75c7361dc.