### PR TITLE
(chore): fix chapter number to use attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ docs/output/*
 work/**/*
 !work/README.md
 #
-04-build/knative/setenv.sh
+**/setenv.sh
 
 src/**
 pom.xml

--- a/03-scaling/knative/autoscaling-configmap.yaml
+++ b/03-scaling/knative/autoscaling-configmap.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-autoscaler
-  labels:
-    serving.knative.dev/release: devel
-data:
-  scale-to-zero-grace-period: 30s
-  stable-window: 60s

--- a/documentation/modules/ROOT/pages/02-basic-fundas.adoc
+++ b/documentation/modules/ROOT/pages/02-basic-fundas.adoc
@@ -24,7 +24,7 @@ Navigate to the tutorial chapter's `knative` folder:
 
 [source,bash,subs="+macros,+attributes"]
 ----
-cd $TUTORIAL_HOME/01-basics/knative
+cd $TUTORIAL_HOME/{basics-repo}/knative
 ----
 
 The following snippet shows how a Knative service YAML will look like:

--- a/documentation/modules/ROOT/pages/03-configs-and-routes.adoc
+++ b/documentation/modules/ROOT/pages/03-configs-and-routes.adoc
@@ -24,7 +24,7 @@ Navigate to the tutorial chapter's folder:
 
 [source,bash,subs="+macros,+attributes"]
 ----
-cd $TUTORIAL_HOME/02-configs-and-routes
+cd $TUTORIAL_HOME/{configs-and-routes-repo}
 ----
 
 === Deploy Configuration revision 1
@@ -211,7 +211,7 @@ When deploying services with service object based approach, the service resource
 For the sake of clarity we will call greeter-00001 as **revision 1** and greeter-00002 as **revision 2**
 ====
 
-Before we start to apply routes, let us open a new terminal and run the following command `$TUTORIAL_HOME/02-configs-and-routes/bin/call.sh`, this command will keep sending requests to greeter route every two seconds which allows us to monitor the changes to the responses as we keep applying the route that will distribute the traffic between the available two revisions.
+Before we start to apply routes, let us open a new terminal and run the following command `$TUTORIAL_HOME/{configs-and-routes-repo}/bin/call.sh`, this command will keep sending requests to greeter route every two seconds which allows us to monitor the changes to the responses as we keep applying the route that will distribute the traffic between the available two revisions.
 
 [#crtd-all-rev1]
 === Send all traffic to revision 1

--- a/documentation/modules/ROOT/pages/04-scaling.adoc
+++ b/documentation/modules/ROOT/pages/04-scaling.adoc
@@ -42,7 +42,7 @@ Navigate to the tutorial chapter's `Knative` folder:
 
 [source,bash,subs="+macros,+attributes"]
 ----
-cd $TUTORIAL_HOME/03-serving/knative
+cd $TUTORIAL_HOME/{scaling-repo}/knative
 ----
 
 The service can be deployed using the command:
@@ -88,7 +88,7 @@ Navigate to the tutorial chapter's `knative` folder:
 
 [source,bash,subs="+macros,+attributes"]
 ----
-cd $TUTORIAL_HOME/01-basics/knative
+cd $TUTORIAL_HOME/{basics-repo}/knative
 ----
 
 The service can be deployed using the command:
@@ -206,7 +206,7 @@ Navigate to the tutorial chapter's `knative` folder:
 
 [source,bash,subs="+macros,+attributes"]
 ----
-cd $TUTORIAL_HOME/03-scaling/knative
+cd $TUTORIAL_HOME/{scaling-repo}/knative
 ----
 
 [source,bash,subs="+macros,+attributes"]

--- a/site.yml
+++ b/site.yml
@@ -4,7 +4,7 @@ runtime:
 site:
   title: Knative Tutorial
   url: https://redhat-developer-demos.github.io/knative-tutorial
-  start_page: v1.0.0@knative-tutorial::index.adoc
+  start_page: v1.1.0-SNAPSHOT@knative-tutorial::index.adoc
 
 content:
   sources:


### PR DESCRIPTION
- fixing realigned chapter folders to point right directory in instructions
- made v1.1.0-SNAPSHOT as default site
- removed stale scaling folder using old folder number

Fixes: #27