### PR TITLE
src: add missing route configuration yaml

### DIFF
--- a/03-configs-and-routes/route/route_all_rev1.yaml
+++ b/03-configs-and-routes/route/route_all_rev1.yaml
@@ -1,0 +1,8 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Route
+metadata:
+  name: greeter
+spec:
+  traffic:
+    - revisionName: $revision
+      percent: 100


### PR DESCRIPTION
This file does not exist, but is referenced [here](https://redhat-developer-demos.github.io/knative-tutorial/knative-tutorial/v1.1.0-SNAPSHOT/03-configs-and-routes.html#crtd-all-rev1).