### PR TITLE
doc: fix typos in chapters 3, 4 and 5

### DIFF
--- a/05-build/knative/setenv.sh.example
+++ b/05-build/knative/setenv.sh.example
@@ -14,4 +14,4 @@ SOURCE_REVISION=${SOURCE_REVISION:-'master'}
 # The Context directory within sources repository which will be used during build
 CONTEXT_DIR=${CONTEXT_DIR:-'java/quarkus'}
 # The fully qualified image name e.g. docker.io/foo/bar:v1.0
-DESTINATION_IMAGE_NAME=${DESTINATION_IMAGE_NAME:'<your container registry url>'}
+DESTINATION_IMAGE_NAME=${DESTINATION_IMAGE_NAME:-'<your container registry url>'}

--- a/documentation/modules/ROOT/pages/03-configs-and-routes.adoc
+++ b/documentation/modules/ROOT/pages/03-configs-and-routes.adoc
@@ -230,7 +230,7 @@ We need to run the service invocation in loop to see the results of traffic dist
 set -eu
 while true
 do
-  http --body $IP_ADDRESS 'Host: greeter.{tutorial-namespace}.example.com'
+  http --body $IP_ADDRESS 'Host:greeter.{tutorial-namespace}.example.com'
   sleep 3
 done;
 ----

--- a/documentation/modules/ROOT/pages/04-scaling.adoc
+++ b/documentation/modules/ROOT/pages/04-scaling.adoc
@@ -437,8 +437,8 @@ spec:
                 path: /healthz
 ----
 
-<1> Will allow each service pod to handle max of 10 in-flight requests per pod before automatically scaling to new pods.
-<2> The deployment of this service will always have a minimum of 2 pods.
+<1> The deployment of this service will always have a minimum of 2 pods.
+<2> Will allow each service pod to handle max of 10 in-flight requests per pod before automatically scaling to new pods.
 
 [#scaling-run-min-scale]
 [source,bash,subs="+macros,+attributes"]


### PR DESCRIPTION
The example code for the polling bash script has an errant space in the header that causes the `http` command to fail, and the annotation descriptions for `service-min-scale.yaml` were reversed.