### PR TITLE
doc: add information about remote image repository

### DIFF
--- a/documentation/modules/ROOT/pages/01-setup.adoc
+++ b/documentation/modules/ROOT/pages/01-setup.adoc
@@ -54,6 +54,10 @@ The following CLI tools are required for running the exercises in this tutorial.
 
 |===
 
+[#remote-docker-repository]
+== Remote Repository
+For some parts of the tutorial, you will be pushing and pulling container images to and from a remote image repository. You will need an account with publish rights. As of this writing, knative works best with https://hub.docker.com[Docker Hub].
+
 [#download-tutorial-sources]
 == Download Tutorial Sources
 Before we start setting up the environment, let's clone the tutorial sources and set the `TUTORIAL_HOME` environment variable to point to the root directory of the tutorial:


### PR DESCRIPTION
Hi @kameshsampath. I got to the end of chapter 5 before I discovered that things don't work very well with quay.io yet. It might be good to warn folks in advance that they should be working with Docker Hub instead. @burrsutter mentioned that you have been able to get this working with quay.io, but was not clear on the details. Do you think having a brief section in the beginning about using Docker Hub  would be good?