### PR TITLE
doc: add HTTP Accept header to build post request

### DIFF
--- a/documentation/modules/ROOT/pages/05-build/build.adoc
+++ b/documentation/modules/ROOT/pages/05-build/build.adoc
@@ -333,7 +333,7 @@ include::ROOT:partial$invoke-service.adoc[tag=env]
 [#build-run-service-call]
 [source,bash,subs="+macros,+attributes",linenums]
 ----
-http POST $IP_ADDRESS \
+http POST $IP_ADDRESS 'Accept:*/*' \
   'Host:event-greeter.{tutorial-namespace}.example.com'  \
    message="test message"
 ----


### PR DESCRIPTION
I found that with the quarkus application, it was necessary to add the `Accept: */*` header to the `POST` request. Otherwise, the server returns this response:

```
[lanceball@localhost knative]$ http POST $IP_ADDRESS 'Host:event-greeter.knativetutorial.example.com' message="test message"
HTTP/1.1 406 Not Acceptable
content-length: 0
date: Wed, 10 Apr 2019 19:23:28 GMT
server: envoy
x-envoy-upstream-service-time: 1
```
