### PR TITLE
Add note for installing Minikube vs Minishift vs Openshift

### DIFF
--- a/documentation/modules/ROOT/pages/01-setup.adoc
+++ b/documentation/modules/ROOT/pages/01-setup.adoc
@@ -6,6 +6,8 @@ include::_attributes.adoc[]
 
 The following CLI tools are required for running the exercises in this tutorial. Please have them installed and configured before you get started with any of the tutorial chapters.
 
+You don't have to have both `Minikube` and `Minishift`. Also, if you have an existing OpenShift cluster you can also use it.
+
 [cols="3*^,3*.",options="header"]
 |===
 |**Tool**|**macOS**|**Fedora**

--- a/documentation/modules/ROOT/pages/_partials/openshift-setup.adoc
+++ b/documentation/modules/ROOT/pages/_partials/openshift-setup.adoc
@@ -1,5 +1,5 @@
 [#install-knative-openshift]
-=== OpenShift 
+=== Install with OpenShift 
 
 For OpenShift Knative installations we will use the OpenShift Cloud Function's https://github.com/openshift-cloud-functions/knative-operators[Knative Operators].
 


### PR DESCRIPTION
Added some short text explaining that either Minishift or Minukube is good.

When I did the tutorial, I thought there are some parts specific to OpenShift/Minishift in the later chapters as minishift is also listed in the prereqs in addition to minikube. Tried to get rid of this confusion in this PR.