### PR TITLE
Upgrade tutorial to Knative 0.5.0

### DIFF
--- a/documentation/modules/ROOT/pages/04-scaling.adoc
+++ b/documentation/modules/ROOT/pages/04-scaling.adoc
@@ -21,8 +21,7 @@ include::partial$build-containers.adoc[tag=greeter]
 [#scaling-modify-configmap]
 == Setting Configmap Defaults
 
-Knative v0.4.0 changed how the default configuration map values are set and provided.
-For the purposes of this section, lets apply a few defaults.
+Let's apply a few defaults to Knative's auto scaling configuration.
 
 [.text-center]
 .link:{github-repo}/{scaling-repo}/knative/autoscaling-configmap.yaml[autoscaling-configmap.yaml]

--- a/documentation/modules/ROOT/pages/_attributes.adoc
+++ b/documentation/modules/ROOT/pages/_attributes.adoc
@@ -8,15 +8,15 @@
 :eventing-repo: 06-eventing
 :experimental:
 :minikube-version: v1.0.0
-:knative-version: v0.4.0
+:knative-version: v0.5.0
 :openshift-version: v3.11
 :minishift-version: v1.30.0+186b034
 
 :knative-serving-repo: https://github.com/knative/serving/releases/download
-:knative-serving-version: v0.4.0
+:knative-serving-version: v0.5.0
 :knative-build-repo: https://github.com/knative/build/releases/download
-:knative-build-version: v0.4.0
+:knative-build-version: v0.5.0
 :knative-eventing-repo: https://github.com/knative/eventing/releases/download
-:knative-eventing-version: v0.4.0
+:knative-eventing-version: v0.5.0
 :knative-sources-repo: https://github.com/knative/eventing-sources/releases/download
-:knative-sources-version: v0.4.0
+:knative-sources-version: v0.5.0

--- a/documentation/modules/ROOT/pages/_partials/minikube-setup.adoc
+++ b/documentation/modules/ROOT/pages/_partials/minikube-setup.adoc
@@ -65,10 +65,9 @@ istio-pilot-86bb4fcbbd-ptz7n               2/2     Running     0          6h35m
 istio-pilot-86bb4fcbbd-s9qxl               2/2     Running     0          6h34m
 istio-pilot-86bb4fcbbd-xd887               2/2     Running     0          6h34m
 istio-policy-5c4d9ff96b-tzkbw              2/2     Running     0          6h35m
+istio-security-post-install-xdxc7          0/1     Completed   0          6h35m
 istio-sidecar-injector-6977b5cf5b-9wsjw    1/1     Running     0          6h35m
-istio-statsd-prom-bridge-b44b96d7b-x85xr   1/1     Running     0          6h35m
 istio-telemetry-7676df547f-55p6c           2/2     Running     0          6h35m
-knative-ingressgateway-75644679c7-5xwx6    1/1     Running     0          6h27m
 ----
 
 [#install-knative-serving]
@@ -146,7 +145,7 @@ build-webhook-6bb747665f-trjxg      1/1     Running   0          6h32m
 [source,bash,subs="+macros,+attributes"]
 ----
 kubectl apply --filename {knative-eventing-repo}/{knative-eventing-version}/release.yaml && \
-kubectl apply --filename {knative-sources-repo}/{knative-sources-version}/release.yaml && \
+kubectl apply --filename {knative-sources-repo}/{knative-sources-version}/eventing-sources.yaml && \
 kubectl apply --filename https://raw.githubusercontent.com/knative/serving/{knative-serving-version}/third_party/config/build/clusterrole.yaml
 ----
 copyToClipboard::run-install-knative-eventing[]


### PR DESCRIPTION
Title says it. 

There weren't many problems.

Only went through the `minukube` and `kubectl` path though. Didn't try the `minishift` and `oc` path.

Comments about changes are inline.

I found out 2 things during this work and created separate tickets for them:
* https://github.com/redhat-developer-demos/knative-tutorial/issues/147 : cron job source service pod is not created when there is no sink service
* https://github.com/redhat-developer-demos/knative-tutorial/issues/148 : Eventing tutorial should use Brokers and Triggers of Knative 0.5.0