### PR TITLE
Eventing trigger broker

### DIFF
--- a/06-eventing/knative/event-source-broker.yaml
+++ b/06-eventing/knative/event-source-broker.yaml
@@ -3,10 +3,19 @@ kind: ContainerSource
 metadata:
   name: heartbeat-event-source
 spec:
-  image: docker.io/matzew/kube-heartbeat
+  image: quay.io/openshift-knative/knative-eventing-sources-heartbeats:v0.5.0
   args:
     - '--label="Thanks for doing Knative Tutorial"'
-    - '--period=1000'
+    - '--period=1'
+  env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
   sink:
     apiVersion: eventing.knative.dev/v1alpha1
     kind: Broker

--- a/06-eventing/knative/event-source-broker.yaml
+++ b/06-eventing/knative/event-source-broker.yaml
@@ -1,0 +1,13 @@
+apiVersion: sources.eventing.knative.dev/v1alpha1
+kind: ContainerSource
+metadata:
+  name: heartbeat-event-source
+spec:
+  image: docker.io/matzew/kube-heartbeat
+  args:
+    - '--label="Thanks for doing Knative Tutorial"'
+    - '--period=1000'
+  sink:
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: Broker
+    name: default

--- a/06-eventing/knative/trigger.yaml
+++ b/06-eventing/knative/trigger.yaml
@@ -1,0 +1,13 @@
+apiVersion: eventing.knative.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: event-greeter-trigger
+spec:
+  filter:
+    sourceAndType:
+      type: dev.knative.source.heartbeats
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1alpha1
+      kind: Service
+      name: event-greeter

--- a/06-eventing/knative/trigger.yaml
+++ b/06-eventing/knative/trigger.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   filter:
     sourceAndType:
-      type: dev.knative.source.heartbeats
+      type: dev.knative.eventing.samples.heartbeat
   subscriber:
     ref:
       apiVersion: serving.knative.dev/v1alpha1

--- a/documentation/modules/ROOT/nav.adoc
+++ b/documentation/modules/ROOT/nav.adoc
@@ -94,6 +94,15 @@
 **** xref:06-eventing/eventing-src-sub.adoc#eventing-gen-subscriber-service[Generate Service]
 **** xref:06-eventing/eventing-src-sub.adoc#eventing-deploy-subscriber-service[Deploy Service]
 *** xref:06-eventing/eventing-src-sub.adoc#eventing-cleanup[Cleanup]
+** xref:06-eventing/eventing-trigger-broker.adoc[Triggers and Brokers]
+*** xref:06-eventing/eventing-trigger-broker.adoc#events-triggers-brokers[Events, Triggers and Brokers]
+*** xref:06-eventing/eventing-trigger-broker.adoc#broker[Broker]
+*** xref:06-eventing/eventing-trigger-broker.adoc#eventing-service[Service]
+*** xref:06-eventing/eventing-trigger-broker.adoc#eventing-event-source[Event Source]
+*** xref:06-eventing/eventing-trigger-broker.adoc#eventing-trigger[Trigger]
+*** xref:06-eventing/eventing-trigger-broker.adoc#eventing-verification[Verification]
+*** xref:06-eventing/eventing-trigger-broker.adoc#eventing-cleanup[Cleanup]
+
 ** xref:06-eventing/eventing.adoc#eventing-watch-logs[Watching Logs]
 
 * xref:faq.adoc[8. Frequently Asked Questions]

--- a/documentation/modules/ROOT/pages/06-eventing/eventing-trigger-broker.adoc
+++ b/documentation/modules/ROOT/pages/06-eventing/eventing-trigger-broker.adoc
@@ -1,0 +1,307 @@
+
+= Triggers and Brokers
+include::_attributes.adoc[]
+
+[#events-triggers-brokers]
+== Events, Triggers and Brokers
+
+With Knative 0.5.0, Broker and Trigger objects are introduced to make event filtering easier.
+
+Brokers provide selection of events by attributes. They receive events and forwards them to subscribers defined by matching Triggers.
+
+Triggers provide a way of filtering of events by attributes. They are attached to subscribers and make the subscribers receive the events only they are interested in.
+
+include::partial$eventing-snippets.adoc[tag=eventing-nav-folder]
+
+[#broker]
+== Broker
+
+First of all, we need to create a Broker. Knative eventing provides a Broker named `default` when a special label is added to a namespace.
+
+[tabs]
+====
+kubectl::
++
+--
+[#eventing-trigger-broker-label-namespace]
+[source,bash,subs="+macros,+attributes",linenums]
+----
+kubectl label namespace {tutorial-namespace} knative-eventing-injection=enabled
+----
+copyToClipboard::eventing-trigger-broker-label-namespace[]
+
+--
+oc::
++
+--
+[#eventing-trigger-broker-oc-label-namespace]
+[source,bash,subs="+macros,+attributes",linenums]
+----
+oc label namespace {tutorial-namespace} knative-eventing-injection=enabled
+----
+copyToClipboard::eventing-trigger-broker-oc-label-namespace[]
+--
+====
+
+This will create the `default` broker. Execute the following command to see it:
+
+[tabs]
+====
+kubectl::
++
+--
+[#eventing-trigger-broker-see-broker]
+[source,bash,subs="+macros,+attributes",linenums]
+----
+kubectl -n {tutorial-namespace} get brokers.eventing.knative.dev
+----
+copyToClipboard::eventing-trigger-broker-see-broker[]
+
+--
+oc::
++
+--
+[#eventing-trigger-broker-oc-see-broker]
+[source,bash,subs="+macros,+attributes",linenums]
+----
+oc label namespace {tutorial-namespace} get brokers.eventing.knative.dev
+----
+copyToClipboard::eventing-trigger-broker-oc-see-broker[]
+--
+====
+
+Output should be similar to below:
+
+[source,bash,subs="+macros,+attributes"]
+----
+NAME      READY     REASON    HOSTNAME                                           AGE
+default   True                default-broker.knativetutorial.svc.cluster.local   2m
+----
+
+Labeling the namespace will also create some pods that are related to the `default` broker.
+
+[tabs]
+====
+kubectl::
++
+--
+[#eventing-trigger-broker-see-broker-pods]
+[source,bash,subs="+macros,+attributes",linenums]
+----
+kubectl -n {tutorial-namespace} get pods
+----
+copyToClipboard::eventing-trigger-broker-see-broker-pods[]
+
+--
+oc::
++
+--
+[#eventing-trigger-broker-oc-see-broker-pods]
+[source,bash,subs="+macros,+attributes",linenums]
+----
+oc label namespace {tutorial-namespace} get pods
+----
+copyToClipboard::eventing-trigger-broker-oc-see-broker-pods[]
+--
+====
+
+Running  the above command should return the following result:
+
+[source,bash,subs="+macros,+attributes"]
+----
+NAME                                      READY     STATUS    RESTARTS   AGE
+default-broker-filter-5bb94d8ddf-r9j4v    2/2       Running   1          2m43s
+default-broker-ingress-59b9b4985c-8n6d4   2/2       Running   1          2m43s
+----
+
+
+[#eventing-service]
+== Service 
+
+[#eventing-gen-service]
+=== Generate Service
+
+Run the following command to create the Knative service that will be used as the subscriber for the events that are going to be published later:
+
+[#eventing-run-gen-service]
+[source,bash,subs="+macros,+attributes",linenums]
+----
+yq w -i service.yaml spec.runLatest.configuration.revisionTemplate.spec.container.image pass:[$DESTINATION_IMAGE_NAME]
+----
+copyToClipboard::eventing-run-gen-service[]
+
+[.text-center]
+.service.yaml
+[source,yaml,linenums]
+----
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: event-greeter
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        metadata:
+          labels:
+            app: event-greeter
+        spec:
+          container:
+            image: docker.io/demo/event-greeter:0.0.1 <1>
+----
+
+<1> Set from `pass:[${DESTINATION_IMAGE_NAME}]` environment variable --  the fully qualified container image that will be pushed to the registry as part of the build --
+
+Refer to xref:ROOT:{build-repo}/build.adoc#build-set-env[Build Environment Variables]
+
+[NOTE,subs="macros+"]
+====
+If you have skipped the xref:ROOT:{build-repo}/build.adoc[Build] or xref:ROOT:05-build/build-templates.adoc[Build Templates] and dont have the container image of `event-greeter`; then you can update the Knative serving service to use the pre-built event-greeter image available at `quay.io/rhdevelopers/knative-tutorial-greeter:0.0.1`
+====
+
+[#eventing-deploy-service]
+=== Deploy Service
+
+Run the following commands to create the service:
+
+:doc-sec: deploy-service
+:url: {github-repo}/{eventing-repo}/knative/service.yaml
+:url-alt-text: service.yaml
+include::ROOT:partial$deploy-knative-resources.adoc[]
+
+
+[#eventing-event-source]
+== Event Source
+[.text-center]
+.link:{github-repo}/{eventing-repo}/knative/event-source-broker.yaml[event-source-broker.yaml]
+[source,yaml,linenums]
+----
+apiVersion: sources.eventing.knative.dev/v1alpha1
+kind: ContainerSource #<1>
+metadata:
+  name: heartbeat-event-source
+spec:
+  image: docker.io/matzew/kube-heartbeat  #<2>
+  args: #<3>                                            
+    - '--label="Thanks for doing Knative Tutorial"' 
+    - '--period=1000'
+  sink: #<4>                                             
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: Broker
+    name: default
+----
+
+<1> The type of event source. `ContainerSource` type is basically a container sending events.
+<2> The image to run with this `ContainerSource`.
+<3> Arguments for the `ContainerSource` image. `label` in this particular case is what the image will be sending as event data and `period` is how often it will send events.
+<4> Sink here is the `default` broker created earlier. So, the `default` broker will receive the events sent by this event source.
+
+Run the following commands to create the event source resources:
+
+:doc-sec: eventing-trigger-broker-create-event-source
+:url: {github-repo}/{eventing-repo}/knative/event-source-broker.yaml
+:url-alt-text: event-source-broker.yaml
+include::ROOT:partial$deploy-knative-resources.adoc[]
+
+[#eventing-trigger]
+== Trigger
+[.text-center]
+.link:{github-repo}/{eventing-repo}/knative/trigger.yaml[trigger.yaml]
+[source,yaml,linenums]
+----
+apiVersion: eventing.knative.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: event-greeter-trigger
+spec:
+  filter:
+    sourceAndType:
+      type: dev.knative.source.heartbeats #<1>
+  subscriber: #<2>
+    ref:
+      apiVersion: serving.knative.dev/v1alpha1
+      kind: Service #<3>
+      name: event-greeter #<4>
+----
+
+<1> The event type to filter on. The event type `dev.knative.source.heartbeats` is the one used by the `ContainerSource` image we deployed earlier. 
+<2> Definition of the subscriber for the events that are matched by the filter of the trigger.
+<3> In this case, the subscriber is a service.
+<4> Subscriber service name. This trigger will make sure the events filtered will be sent to this service.
+
+Run the following commands to create the event source resources:
+
+:doc-sec: eventing-trigger-broker-create-trigger
+:url: {github-repo}/{eventing-repo}/knative/trigger.yaml
+:url-alt-text: trigger.yaml
+include::ROOT:partial$deploy-knative-resources.adoc[]
+
+[#eventing-verification]
+== Verification
+
+=== Logs
+
+[NOTE]
+====
+When you xref:{eventing-repo}/eventing.adoc#eventing-watch-logs[watch logs], you will notice this data being delivered to the service.
+====
+
+[#eventing-see-what-you-have-deployed]
+=== See what you have deployed
+
+==== sources
+include::partial$knative-objects.adoc[tag=knative-container-event-sources]
+
+==== services
+include::partial$knative-objects.adoc[tag=knative-event-services]
+
+==== triggers
+include::partial$knative-objects.adoc[tag=knative-triggers]
+
+
+[#eventing-cleanup]
+== Cleanup
+[tabs]
+====
+kubectl::
++
+--
+[#eventing-run-trigger-broker-cleanup]
+[source,bash,subs="+macros,+attributes",linenums]
+----
+kubectl -n {tutorial-namespace} delete services.serving.knative.dev event-greeter
+kubectl -n {tutorial-namespace} delete \
+ containersource.sources.eventing.knative.dev heartbeat-event-source
+kubectl -n {tutorial-namespace} delete triggers.eventing.knative.dev event-greeter-trigger
+kubectl label namespace {tutorial-namespace} knative-eventing-injection-
+kubectl -n {tutorial-namespace} delete brokers.eventing.knative.dev default
+kubectl -n {tutorial-namespace} delete \
+ clusterchannelprovisioners.eventing.knative.dev in-memory 
+kubectl -n {tutorial-namespace} delete \
+ clusterchannelprovisioners.eventing.knative.dev in-memory-channel 
+----
+copyToClipboard::eventing-run-trigger-broker-cleanup[]
+
+--
+oc::
++
+--
+[#eventing-run-oc-trigger-broker-cleanup]
+[source,bash,subs="+macros,+attributes",linenums]
+----
+oc -n {tutorial-namespace} delete services.serving.knative.dev event-greeter
+oc -n {tutorial-namespace} delete \
+ containersource.sources.eventing.knative.dev heartbeat-event-source
+oc -n {tutorial-namespace} delete triggers.eventing.knative.dev event-greeter-trigger
+oc label namespace {tutorial-namespace} knative-eventing-injection-
+oc -n {tutorial-namespace} delete brokers.eventing.knative.dev default
+oc -n {tutorial-namespace} delete \
+ clusterchannelprovisioners.eventing.knative.dev in-memory 
+oc -n {tutorial-namespace} delete \
+ clusterchannelprovisioners.eventing.knative.dev in-memory-channel
+----
+copyToClipboard::eventing-run-oc-trigger-broker-cleanup[]
+--
+====
+
+NOTE: You can also delete xref:ROOT:{build-repo}/build.adoc#build-apply-prereq-resources[pre-req resources] that were created if you don't need them anymore.

--- a/documentation/modules/ROOT/pages/06-eventing/eventing-trigger-broker.adoc
+++ b/documentation/modules/ROOT/pages/06-eventing/eventing-trigger-broker.adoc
@@ -181,18 +181,27 @@ kind: ContainerSource #<1>
 metadata:
   name: heartbeat-event-source
 spec:
-  image: docker.io/matzew/kube-heartbeat  #<2>
-  args: #<3>                                            
-    - '--label="Thanks for doing Knative Tutorial"' 
-    - '--period=1000'
-  sink: #<4>                                             
+  image: quay.io/openshift-knative/knative-eventing-sources-heartbeats:v0.5.0 #<2>
+  args: #<3>
+    - '--label="Thanks for doing Knative Tutorial"'
+    - '--period=1'
+  env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+  sink: #<4>
     apiVersion: eventing.knative.dev/v1alpha1
     kind: Broker
     name: default
 ----
 
 <1> The type of event source. `ContainerSource` type is basically a container sending events.
-<2> The image to run with this `ContainerSource`.
+<2> The image to run with this `ContainerSource`. Source of the image is available link:https://github.com/knative/eventing-sources/blob/v0.5.0/cmd/heartbeats/main.go[here].
 <3> Arguments for the `ContainerSource` image. `label` in this particular case is what the image will be sending as event data and `period` is how often it will send events.
 <4> Sink here is the `default` broker created earlier. So, the `default` broker will receive the events sent by this event source.
 
@@ -216,7 +225,7 @@ metadata:
 spec:
   filter:
     sourceAndType:
-      type: dev.knative.source.heartbeats #<1>
+      type: dev.knative.eventing.samples.heartbeat #<1>
   subscriber: #<2>
     ref:
       apiVersion: serving.knative.dev/v1alpha1
@@ -224,7 +233,7 @@ spec:
       name: event-greeter #<4>
 ----
 
-<1> The event type to filter on. The event type `dev.knative.source.heartbeats` is the one used by the `ContainerSource` image we deployed earlier. 
+<1> The event type to filter on. The event type `dev.knative.eventing.samples.heartbeat` is the one used by the `ContainerSource` image we deployed earlier. 
 <2> Definition of the subscriber for the events that are matched by the filter of the trigger.
 <3> In this case, the subscriber is a service.
 <4> Subscriber service name. This trigger will make sure the events filtered will be sent to this service.

--- a/documentation/modules/ROOT/pages/06-eventing/eventing.adoc
+++ b/documentation/modules/ROOT/pages/06-eventing/eventing.adoc
@@ -3,11 +3,13 @@ include::_attributes.adoc[]
 
 At the end of this chapter you will know and understand:
 
-* What is an event source ?
-* What is a channel ?
-* What is a subscriber ?
-* How to make a Knative serving service receive an event ?
-* How to make a service a subscriber of an event ?
+* What is an event source?
+* What is a channel?
+* What is a subscriber?
+* What is a trigger?
+* What is a broker?
+* How to make a Knative serving service receive an event?
+* How to make a service a subscriber of an event?
 
 [#eventing-prerequisite]
 == Prerequisite 

--- a/documentation/modules/ROOT/pages/_partials/knative-objects.adoc
+++ b/documentation/modules/ROOT/pages/_partials/knative-objects.adoc
@@ -365,4 +365,4 @@ copyToClipboard::oc-knative-triggers[]
 --
 ====
 
-#end::knative-event-triggers[]
+#end::knative-triggers[]

--- a/documentation/modules/ROOT/pages/_partials/knative-objects.adoc
+++ b/documentation/modules/ROOT/pages/_partials/knative-objects.adoc
@@ -258,6 +258,33 @@ copyToClipboard::oc-knative-event-sources[]
 
 #end::knative-event-cronjob-sources[]
 
+#tag::knative-container-event-sources[]
+[tabs]
+====
+kubectl::
++
+--
+[#knative-container-event-sources]
+[source,bash,subs="+macros,+attributes"]
+----
+kubectl --namespace {tutorial-namespace} get containersources.sources.eventing.knative.dev heartbeat-event-source
+----
+copyToClipboard::knative-container-event-sources[]
+--
+oc::
++
+--
+[#oc-knative-container-event-sources]
+[source,bash,subs="+macros,+attributes"]
+----
+oc --namespace {tutorial-namespace} get containersources.sources.eventing.knative.dev heartbeat-event-source
+----
+copyToClipboard::oc-knative-container-event-sources[]
+--
+====
+
+#end::knative-container-event-sources[]
+
 #tag::knative-event-subscribers[]
 [tabs]
 ====
@@ -304,7 +331,6 @@ oc::
 [#oc-knative-services]
 [source,bash,subs="+macros,+attributes"]
 ----
-# get a Knative Service (short name ksvc) called greeter
 oc --namespace {tutorial-namespace}  get services.serving.knative.dev event-greeter 
 ----
 copyToClipboard::oc-knative-services[]
@@ -312,3 +338,31 @@ copyToClipboard::oc-knative-services[]
 ====
 
 #end::knative-event-services[]
+
+
+#tag::knative-triggers[]
+[tabs]
+====
+kubectl::
++
+--
+[#knative-triggers]
+[source,bash,subs="+macros,+attributes"]
+----
+kubectl --namespace {tutorial-namespace}  get triggers.eventing.knative.dev event-greeter-trigger  
+----
+copyToClipboard::knative-triggers[]
+--
+oc::
++
+--
+[#oc-knative-triggers]
+[source,bash,subs="+macros,+attributes"]
+----
+oc --namespace {tutorial-namespace}  get triggers.eventing.knative.dev event-greeter-trigger 
+----
+copyToClipboard::oc-knative-triggers[]
+--
+====
+
+#end::knative-event-triggers[]

--- a/documentation/modules/ROOT/pages/_partials/watching-logs.adoc
+++ b/documentation/modules/ROOT/pages/_partials/watching-logs.adoc
@@ -1,7 +1,9 @@
 [kube-ns='knativetutorial']
 [kube-svc='']
 
-Since a Cron job source is used in this section of the tutorial, it would emit events every minute. We can watch the logs of the service to see the messages delivered.
+In the eventing related subsections of this tutorial, event sources are configured to emit events every minute
+with a `CronJobSource` or with a `ContainerSource`.  
+We can watch the logs of the service to see the messages delivered.
 
 The logs could be watched using the command:
 [tabs]

--- a/documentation/modules/ROOT/pages/_partials/watching-logs.adoc
+++ b/documentation/modules/ROOT/pages/_partials/watching-logs.adoc
@@ -1,8 +1,7 @@
 [kube-ns='knativetutorial']
 [kube-svc='']
 
-In the eventing related subsections of this tutorial, event sources are configured to emit events every minute
-with a `CronJobSource` or with a `ContainerSource`.  
+In the eventing related subsections of this tutorial, event sources are configured to emit events every minute with a `CronJobSource` or with a `ContainerSource`.  
 We can watch the logs of the service to see the messages delivered.
 
 The logs could be watched using the command:


### PR DESCRIPTION
~~Depends on https://github.com/redhat-developer-demos/knative-tutorial/pull/146~~
Fixes https://github.com/redhat-developer-demos/knative-tutorial/issues/148

~~Docs are not written yet. Just pushed the YAML.~~
UPDATE: Docs are pushed now.

### Notes:

I originally wanted to use a CronJobSource with the event type listened by our broker above, but CronJobSource doesn't support setting up event type [1](https://knative.dev/docs/reference/eventing/eventing-sources-api/#CronJobSource) [2](https://github.com/knative/eventing/blob/47e3de90f79d7585b8ead65849253b24a7e52661/config/300-cronjobsource.yaml#L45).

I was told that CronJobSource uses a predefined event type at the moment.

So, I used a container event source ~~@matzew created. That event source creates events using Docker image docker.io/matzew/kube-heartbeat . @kameshsampath We need to push that to RH developers Docker hub account. Source for that image is [here](https://github.com/matzew/heartbeat).~~
UPDATE: @matzew pointed me at a good image.

cc @matzew