### PR TITLE
Update Camel-K examples for use with Camel-K version 1.0.0-M1

### DIFF
--- a/advanced/camel-k/knative/channels.yaml
+++ b/advanced/camel-k/knative/channels.yaml
@@ -6,7 +6,7 @@ spec:
   provisioner:
     apiVersion: eventing.knative.dev/v1alpha1
     kind: ClusterChannelProvisioner
-    name: in-memory-channel
+    name: in-memory
 
 ---
 apiVersion: eventing.knative.dev/v1alpha1
@@ -17,4 +17,4 @@ spec:
   provisioner:
     apiVersion: eventing.knative.dev/v1alpha1
     kind: ClusterChannelProvisioner
-    name: in-memory-channel
+    name: in-memory

--- a/advanced/camel-k/pom.xml
+++ b/advanced/camel-k/pom.xml
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-parent</artifactId>
-        <version>2.23.1</version>
+        <version>3.0.0-M4</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/advanced/camel-k/quickstart/pom.xml
+++ b/advanced/camel-k/quickstart/pom.xml
@@ -25,19 +25,19 @@
 
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-aws</artifactId>
+      <artifactId>camel-aws-s3</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.apache.camel.k</groupId>
       <artifactId>camel-knative</artifactId>
-      <version>0.3.0-SNAPSHOT</version>
+      <version>1.0.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.camel.k</groupId>
       <artifactId>camel-knative-http</artifactId>
-      <version>0.3.0-SNAPSHOT</version>
+      <version>1.0.0</version>
     </dependency>
 
     <dependency>

--- a/advanced/camel-k/quickstart/src/main/java/CartoonGenreRouter.java
+++ b/advanced/camel-k/quickstart/src/main/java/CartoonGenreRouter.java
@@ -11,7 +11,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.s3.S3Component;
 import org.apache.camel.component.aws.s3.S3Constants;
 import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.processor.idempotent.MemoryIdempotentRepository;
+import org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository;
 import org.apache.camel.spi.IdempotentRepository;
 
 /**

--- a/advanced/camel-k/quickstart/src/main/java/CartoonMessagesMover.java
+++ b/advanced/camel-k/quickstart/src/main/java/CartoonMessagesMover.java
@@ -11,7 +11,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.s3.S3Component;
 import org.apache.camel.component.aws.s3.S3Constants;
 import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.processor.idempotent.MemoryIdempotentRepository;
+import org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository;
 import org.apache.camel.spi.IdempotentRepository;
 
 /**

--- a/advanced/camel-k/quickstart/src/main/java/ComedyGenreHandler.java
+++ b/advanced/camel-k/quickstart/src/main/java/ComedyGenreHandler.java
@@ -12,7 +12,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.s3.S3Component;
 import org.apache.camel.component.aws.s3.S3Constants;
 import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.language.XPath;
+import org.apache.camel.language.xpath.XPath;
 
 /**
  * The Camel route that handles messages from Knative Channel &quot;genre-comedy&quot; and uploads them to the s3 bucket

--- a/advanced/camel-k/quickstart/src/main/java/OthersGenreHandler.java
+++ b/advanced/camel-k/quickstart/src/main/java/OthersGenreHandler.java
@@ -12,7 +12,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.s3.S3Component;
 import org.apache.camel.component.aws.s3.S3Constants;
 import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.language.XPath;
+import org.apache.camel.language.xpath.XPath;
 
 /**
  * The Camel route that handles messages from Knative Channel &quot;genre-others&quot; and uploads them to the s3 bucket

--- a/advanced/camel-k/quickstart/src/test/java/com/example/camel/DummyRoute.java
+++ b/advanced/camel-k/quickstart/src/test/java/com/example/camel/DummyRoute.java
@@ -1,8 +1,7 @@
 package com.example.camel;
 
-import org.apache.camel.Body;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.language.XPath;
+import org.apache.camel.language.xpath.XPath;
 import org.apache.camel.test.AvailablePortFinder;
 
 public class DummyRoute extends RouteBuilder {

--- a/advanced/camel-k/quickstart/src/test/java/com/example/camel/QuickStartApp.java
+++ b/advanced/camel-k/quickstart/src/test/java/com/example/camel/QuickStartApp.java
@@ -1,7 +1,7 @@
 package com.example.camel;
 
 import org.apache.camel.impl.DefaultCamelContext;
-import org.apache.camel.impl.SimpleRegistry;
+import org.apache.camel.support.SimpleRegistry;
 
 /**
  * A Camel Application

--- a/advanced/camel-k/quickstart/src/test/java/com/example/camel/QuickStartRoute.java
+++ b/advanced/camel-k/quickstart/src/test/java/com/example/camel/QuickStartRoute.java
@@ -13,7 +13,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.s3.S3Component;
 import org.apache.camel.component.aws.s3.S3Constants;
 import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.processor.idempotent.MemoryIdempotentRepository;
+import org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository;
 import org.apache.camel.spi.IdempotentRepository;
 import org.apache.camel.util.FileUtil;
 

--- a/advanced/camel-k/sortucase/pom.xml
+++ b/advanced/camel-k/sortucase/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-aws</artifactId>
+      <artifactId>camel-aws-s3</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>

--- a/advanced/camel-k/sortucase/src/main/java/com/example/camel/SortAndUpperCase.java
+++ b/advanced/camel-k/sortucase/src/main/java/com/example/camel/SortAndUpperCase.java
@@ -5,16 +5,10 @@ import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.amqp.AMQPComponent;
 import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.model.dataformat.JsonLibrary;
-import org.apache.camel.processor.aggregate.AggregationStrategy;
-import org.apache.camel.util.toolbox.AggregationStrategies;
 import org.apache.qpid.jms.JmsConnectionFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-
 
 public class SortAndUpperCase extends RouteBuilder {
 

--- a/advanced/camel-k/splitter/pom.xml
+++ b/advanced/camel-k/splitter/pom.xml
@@ -19,7 +19,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-aws</artifactId>
+      <artifactId>camel-aws-s3</artifactId>
     </dependency>
     <!-- logging -->
     <dependency>

--- a/advanced/camel-k/splitter/src/main/java/com/example/camel/DownloadAndSplit.java
+++ b/advanced/camel-k/splitter/src/main/java/com/example/camel/DownloadAndSplit.java
@@ -13,7 +13,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.amqp.AMQPComponent;
 import org.apache.camel.component.aws.s3.S3Component;
 import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.processor.idempotent.MemoryIdempotentRepository;
+import org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository;
 import org.apache.camel.spi.IdempotentRepository;
 import org.apache.qpid.jms.JmsConnectionFactory;
 


### PR DESCRIPTION
The tutorial uses Knative v0.7.1. According to this Camel-K [issue](https://github.com/apache/camel-k/issues/919) the compatible Camel-K version for this Knative version is 1.0.0-M1. The instructions for the Camel-K examples need some editing too, but the sources for these web pages doesn't seem to be in a Git repo?!