### PR TITLE
Update Camel-K examples for use with Camel-K version 1.0.0-M3 and Knative version 0.7.1

### DIFF
--- a/advanced/camel-k/knative/channels.yaml
+++ b/advanced/camel-k/knative/channels.yaml
@@ -6,7 +6,7 @@ spec:
   provisioner:
     apiVersion: eventing.knative.dev/v1alpha1
     kind: ClusterChannelProvisioner
-    name: in-memory-channel
+    name: in-memory
 
 ---
 apiVersion: eventing.knative.dev/v1alpha1
@@ -17,4 +17,4 @@ spec:
   provisioner:
     apiVersion: eventing.knative.dev/v1alpha1
     kind: ClusterChannelProvisioner
-    name: in-memory-channel
+    name: in-memory

--- a/advanced/camel-k/pom.xml
+++ b/advanced/camel-k/pom.xml
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-parent</artifactId>
-        <version>3.0.0-RC1</version>
+        <version>3.0.0</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/advanced/camel-k/pom.xml
+++ b/advanced/camel-k/pom.xml
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-parent</artifactId>
-        <version>3.0.0-M4</version>
+        <version>3.0.0-RC1</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/advanced/camel-k/pom.xml
+++ b/advanced/camel-k/pom.xml
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-parent</artifactId>
-        <version>2.23.1</version>
+        <version>3.0.0-M4</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/advanced/camel-k/quickstart/pom.xml
+++ b/advanced/camel-k/quickstart/pom.xml
@@ -25,11 +25,6 @@
 
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-properties</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.camel</groupId>
       <artifactId>camel-aws-s3</artifactId>
     </dependency>
 

--- a/advanced/camel-k/quickstart/pom.xml
+++ b/advanced/camel-k/quickstart/pom.xml
@@ -25,19 +25,19 @@
 
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-aws</artifactId>
+      <artifactId>camel-aws-s3</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.apache.camel.k</groupId>
       <artifactId>camel-knative</artifactId>
-      <version>0.3.0-SNAPSHOT</version>
+      <version>1.0.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.camel.k</groupId>
       <artifactId>camel-knative-http</artifactId>
-      <version>0.3.0-SNAPSHOT</version>
+      <version>1.0.0</version>
     </dependency>
 
     <dependency>

--- a/advanced/camel-k/quickstart/pom.xml
+++ b/advanced/camel-k/quickstart/pom.xml
@@ -25,6 +25,11 @@
 
     <dependency>
       <groupId>org.apache.camel</groupId>
+      <artifactId>camel-properties</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.camel</groupId>
       <artifactId>camel-aws-s3</artifactId>
     </dependency>
 
@@ -42,7 +47,7 @@
 
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-netty4-http</artifactId>
+      <artifactId>camel-netty-http</artifactId>
     </dependency>
 
     <!-- logging -->

--- a/advanced/camel-k/quickstart/src/main/java/CartoonGenreRouter.java
+++ b/advanced/camel-k/quickstart/src/main/java/CartoonGenreRouter.java
@@ -96,7 +96,7 @@ public class CartoonGenreRouter extends RouteBuilder {
 	}
 
 	private static String propertyWithPlaceHolder(PropertiesComponent propertiesComponent, String key) {
-		return propertiesComponent.getPrefixToken() + key + propertiesComponent.getSuffixToken();
+		return PropertiesComponent.PREFIX_TOKEN + key + PropertiesComponent.SUFFIX_TOKEN;
 	}
 
 	IdempotentRepository idmRepo() {

--- a/advanced/camel-k/quickstart/src/main/java/CartoonGenreRouter.java
+++ b/advanced/camel-k/quickstart/src/main/java/CartoonGenreRouter.java
@@ -1,3 +1,10 @@
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.aws.s3.S3Component;
+import org.apache.camel.component.aws.s3.S3Constants;
+import org.apache.camel.spi.IdempotentRepository;
+import org.apache.camel.spi.PropertiesComponent;
+import org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository;
+
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
@@ -7,12 +14,6 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.component.aws.s3.S3Component;
-import org.apache.camel.component.aws.s3.S3Constants;
-import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository;
-import org.apache.camel.spi.IdempotentRepository;
 
 /**
  * A Camel Java DSL Router the uses &quot;Content Based Router EIP &quot; to route the messages based on the cartoon genre
@@ -21,7 +22,7 @@ public class CartoonGenreRouter extends RouteBuilder {
 
 	public void configure() {
 
-		PropertiesComponent pc = getContext().getComponent("properties", PropertiesComponent.class);
+		PropertiesComponent pc = getContext().getPropertiesComponent();
 
 		S3Component s3Component = getContext().getComponent("aws-s3", S3Component.class);
 		s3Component.getConfiguration().setAmazonS3Client(amazonS3Client(pc));

--- a/advanced/camel-k/quickstart/src/main/java/CartoonGenreRouter.java
+++ b/advanced/camel-k/quickstart/src/main/java/CartoonGenreRouter.java
@@ -11,7 +11,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.s3.S3Component;
 import org.apache.camel.component.aws.s3.S3Constants;
 import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.processor.idempotent.MemoryIdempotentRepository;
+import org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository;
 import org.apache.camel.spi.IdempotentRepository;
 
 /**

--- a/advanced/camel-k/quickstart/src/main/java/CartoonMessagesDownloader.java
+++ b/advanced/camel-k/quickstart/src/main/java/CartoonMessagesDownloader.java
@@ -1,3 +1,10 @@
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.aws.s3.S3Component;
+import org.apache.camel.component.aws.s3.S3Constants;
+import org.apache.camel.component.properties.PropertiesComponent;
+
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
@@ -7,12 +14,6 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import org.apache.camel.Exchange;
-import org.apache.camel.Message;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.component.aws.s3.S3Component;
-import org.apache.camel.component.aws.s3.S3Constants;
-import org.apache.camel.component.properties.PropertiesComponent;
 
 /**
  * A Camel Java DSL Router that downloads the file from s3 and sends the content as response

--- a/advanced/camel-k/quickstart/src/main/java/CartoonMessagesDownloader.java
+++ b/advanced/camel-k/quickstart/src/main/java/CartoonMessagesDownloader.java
@@ -102,7 +102,6 @@ public class CartoonMessagesDownloader extends RouteBuilder {
 	}
 
 	private static String propertyWithPlaceHolder(PropertiesComponent propertiesComponent, String key) {
-		return propertiesComponent.getPrefixToken() + key + propertiesComponent.getSuffixToken();
-
+		return PropertiesComponent.PREFIX_TOKEN + key + PropertiesComponent.SUFFIX_TOKEN;
 	}
 }

--- a/advanced/camel-k/quickstart/src/main/java/CartoonMessagesDownloader.java
+++ b/advanced/camel-k/quickstart/src/main/java/CartoonMessagesDownloader.java
@@ -3,7 +3,7 @@ import org.apache.camel.Message;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.s3.S3Component;
 import org.apache.camel.component.aws.s3.S3Constants;
-import org.apache.camel.component.properties.PropertiesComponent;
+import org.apache.camel.spi.PropertiesComponent;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
@@ -22,7 +22,7 @@ public class CartoonMessagesDownloader extends RouteBuilder {
 
 	public void configure() {
 
-		PropertiesComponent pc = getContext().getComponent("properties", PropertiesComponent.class);
+		PropertiesComponent pc = getContext().getPropertiesComponent();
 
 		S3Component s3Component = getContext().getComponent("aws-s3", S3Component.class);
 		s3Component.getConfiguration().setAmazonS3Client(amazonS3Client(pc));

--- a/advanced/camel-k/quickstart/src/main/java/CartoonMessagesMover.java
+++ b/advanced/camel-k/quickstart/src/main/java/CartoonMessagesMover.java
@@ -82,7 +82,7 @@ public class CartoonMessagesMover extends RouteBuilder {
 			if (System.getenv().containsKey(key)) {
 				return System.getenv().getOrDefault(key, defaultValue);
 			} else {
-				return propertiesComponent.parseUri(propertiesComponent.getPrefixToken() + key + propertiesComponent.getSuffixToken());
+				return propertiesComponent.parseUri(PropertiesComponent.PREFIX_TOKEN + key + PropertiesComponent.SUFFIX_TOKEN);
 			}
 		} catch (IllegalArgumentException e) {
 			return defaultValue;

--- a/advanced/camel-k/quickstart/src/main/java/CartoonMessagesMover.java
+++ b/advanced/camel-k/quickstart/src/main/java/CartoonMessagesMover.java
@@ -11,7 +11,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.s3.S3Component;
 import org.apache.camel.component.aws.s3.S3Constants;
 import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.processor.idempotent.MemoryIdempotentRepository;
+import org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository;
 import org.apache.camel.spi.IdempotentRepository;
 
 /**

--- a/advanced/camel-k/quickstart/src/main/java/ComedyGenreHandler.java
+++ b/advanced/camel-k/quickstart/src/main/java/ComedyGenreHandler.java
@@ -2,8 +2,8 @@ import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.s3.S3Component;
 import org.apache.camel.component.aws.s3.S3Constants;
-import org.apache.camel.component.properties.PropertiesComponent;
 import org.apache.camel.language.xpath.XPath;
+import org.apache.camel.spi.PropertiesComponent;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
@@ -23,7 +23,7 @@ public class ComedyGenreHandler extends RouteBuilder {
 
 	public void configure() {
 
-		PropertiesComponent pc = getContext().getComponent("properties", PropertiesComponent.class);
+		PropertiesComponent pc = getContext().getPropertiesComponent();
 
 		//no error handler for this route
 		errorHandler(noErrorHandler());

--- a/advanced/camel-k/quickstart/src/main/java/ComedyGenreHandler.java
+++ b/advanced/camel-k/quickstart/src/main/java/ComedyGenreHandler.java
@@ -103,6 +103,6 @@ public class ComedyGenreHandler extends RouteBuilder {
 	 * @return
 	 */
 	private static String propertyWithPlaceHolder(PropertiesComponent propertiesComponent, String key) {
-		return propertiesComponent.getPrefixToken() + key + propertiesComponent.getSuffixToken();
+		return PropertiesComponent.PREFIX_TOKEN + key + PropertiesComponent.SUFFIX_TOKEN;
 	}
 }

--- a/advanced/camel-k/quickstart/src/main/java/ComedyGenreHandler.java
+++ b/advanced/camel-k/quickstart/src/main/java/ComedyGenreHandler.java
@@ -12,7 +12,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.s3.S3Component;
 import org.apache.camel.component.aws.s3.S3Constants;
 import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.language.XPath;
+import org.apache.camel.language.xpath.XPath;
 
 /**
  * The Camel route that handles messages from Knative Channel &quot;genre-comedy&quot; and uploads them to the s3 bucket

--- a/advanced/camel-k/quickstart/src/main/java/ComedyGenreHandler.java
+++ b/advanced/camel-k/quickstart/src/main/java/ComedyGenreHandler.java
@@ -1,3 +1,10 @@
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.aws.s3.S3Component;
+import org.apache.camel.component.aws.s3.S3Constants;
+import org.apache.camel.component.properties.PropertiesComponent;
+import org.apache.camel.language.xpath.XPath;
+
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
@@ -7,12 +14,6 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import org.apache.camel.LoggingLevel;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.component.aws.s3.S3Component;
-import org.apache.camel.component.aws.s3.S3Constants;
-import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.language.xpath.XPath;
 
 /**
  * The Camel route that handles messages from Knative Channel &quot;genre-comedy&quot; and uploads them to the s3 bucket

--- a/advanced/camel-k/quickstart/src/main/java/OthersGenreHandler.java
+++ b/advanced/camel-k/quickstart/src/main/java/OthersGenreHandler.java
@@ -12,7 +12,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.s3.S3Component;
 import org.apache.camel.component.aws.s3.S3Constants;
 import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.language.XPath;
+import org.apache.camel.language.xpath.XPath;
 
 /**
  * The Camel route that handles messages from Knative Channel &quot;genre-others&quot; and uploads them to the s3 bucket

--- a/advanced/camel-k/quickstart/src/main/java/OthersGenreHandler.java
+++ b/advanced/camel-k/quickstart/src/main/java/OthersGenreHandler.java
@@ -1,3 +1,10 @@
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.aws.s3.S3Component;
+import org.apache.camel.component.aws.s3.S3Constants;
+import org.apache.camel.language.xpath.XPath;
+import org.apache.camel.spi.PropertiesComponent;
+
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
@@ -7,12 +14,6 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import org.apache.camel.LoggingLevel;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.component.aws.s3.S3Component;
-import org.apache.camel.component.aws.s3.S3Constants;
-import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.language.xpath.XPath;
 
 /**
  * The Camel route that handles messages from Knative Channel &quot;genre-others&quot; and uploads them to the s3 bucket
@@ -22,7 +23,7 @@ public class OthersGenreHandler extends RouteBuilder {
 
 	public void configure() {
 
-		PropertiesComponent pc = getContext().getComponent("properties", PropertiesComponent.class);
+		PropertiesComponent pc = getContext().getPropertiesComponent();
 
 		//no error handler for this route
 		errorHandler(noErrorHandler());

--- a/advanced/camel-k/quickstart/src/main/java/OthersGenreHandler.java
+++ b/advanced/camel-k/quickstart/src/main/java/OthersGenreHandler.java
@@ -92,6 +92,6 @@ public class OthersGenreHandler extends RouteBuilder {
 	}
 
 	private static String propertyWithPlaceHolder(PropertiesComponent propertiesComponent, String key) {
-		return propertiesComponent.getPrefixToken() + key + propertiesComponent.getSuffixToken();
+		return PropertiesComponent.PREFIX_TOKEN + key + PropertiesComponent.SUFFIX_TOKEN;
 	}
 }

--- a/advanced/camel-k/quickstart/src/test/java/com/example/camel/DummyRoute.java
+++ b/advanced/camel-k/quickstart/src/test/java/com/example/camel/DummyRoute.java
@@ -1,8 +1,7 @@
 package com.example.camel;
 
-import org.apache.camel.Body;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.language.XPath;
+import org.apache.camel.language.xpath.XPath;
 import org.apache.camel.test.AvailablePortFinder;
 
 public class DummyRoute extends RouteBuilder {

--- a/advanced/camel-k/quickstart/src/test/java/com/example/camel/QuickStartApp.java
+++ b/advanced/camel-k/quickstart/src/test/java/com/example/camel/QuickStartApp.java
@@ -1,7 +1,7 @@
 package com.example.camel;
 
 import org.apache.camel.impl.DefaultCamelContext;
-import org.apache.camel.impl.SimpleRegistry;
+import org.apache.camel.support.SimpleRegistry;
 
 /**
  * A Camel Application

--- a/advanced/camel-k/quickstart/src/test/java/com/example/camel/QuickStartRoute.java
+++ b/advanced/camel-k/quickstart/src/test/java/com/example/camel/QuickStartRoute.java
@@ -13,7 +13,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws.s3.S3Component;
 import org.apache.camel.component.aws.s3.S3Constants;
 import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.processor.idempotent.MemoryIdempotentRepository;
+import org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository;
 import org.apache.camel.spi.IdempotentRepository;
 import org.apache.camel.util.FileUtil;
 

--- a/advanced/camel-k/quickstart/src/test/java/com/example/camel/QuickStartRoute.java
+++ b/advanced/camel-k/quickstart/src/test/java/com/example/camel/QuickStartRoute.java
@@ -105,7 +105,7 @@ public class QuickStartRoute extends RouteBuilder {
             if (System.getenv().containsKey(key)) {
                 return System.getenv().getOrDefault(key, defaultValue);
             } else {
-                return propertiesComponent.parseUri(propertiesComponent.getPrefixToken() + key + propertiesComponent.getSuffixToken());
+                return propertiesComponent.parseUri(PropertiesComponent.PREFIX_TOKEN + key + PropertiesComponent.SUFFIX_TOKEN);
             }
         } catch (IllegalArgumentException e) {
             return defaultValue;

--- a/advanced/camel-k/sortucase/pom.xml
+++ b/advanced/camel-k/sortucase/pom.xml
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-aws</artifactId>
+      <artifactId>camel-aws-s3</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>

--- a/advanced/camel-k/sortucase/src/main/java/com/example/camel/SortAndUpperCase.java
+++ b/advanced/camel-k/sortucase/src/main/java/com/example/camel/SortAndUpperCase.java
@@ -77,7 +77,7 @@ public class SortAndUpperCase extends RouteBuilder {
             if (System.getenv().containsKey(key)) {
                 return System.getenv().getOrDefault(key, defaultValue);
             } else {
-                return propertiesComponent.parseUri(propertiesComponent.getPrefixToken() + key + propertiesComponent.getSuffixToken());
+                return propertiesComponent.parseUri(PropertiesComponent.PREFIX_TOKEN + key + PropertiesComponent.SUFFIX_TOKEN);
             }
         } catch (IllegalArgumentException e) {
             return defaultValue;

--- a/advanced/camel-k/sortucase/src/main/java/com/example/camel/SortAndUpperCase.java
+++ b/advanced/camel-k/sortucase/src/main/java/com/example/camel/SortAndUpperCase.java
@@ -1,14 +1,14 @@
 package com.example.camel;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.amqp.AMQPComponent;
 import org.apache.camel.component.properties.PropertiesComponent;
 import org.apache.qpid.jms.JmsConnectionFactory;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class SortAndUpperCase extends RouteBuilder {
 

--- a/advanced/camel-k/sortucase/src/main/java/com/example/camel/SortAndUpperCase.java
+++ b/advanced/camel-k/sortucase/src/main/java/com/example/camel/SortAndUpperCase.java
@@ -5,16 +5,10 @@ import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.amqp.AMQPComponent;
 import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.model.dataformat.JsonLibrary;
-import org.apache.camel.processor.aggregate.AggregationStrategy;
-import org.apache.camel.util.toolbox.AggregationStrategies;
 import org.apache.qpid.jms.JmsConnectionFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-
 
 public class SortAndUpperCase extends RouteBuilder {
 

--- a/advanced/camel-k/splitter/pom.xml
+++ b/advanced/camel-k/splitter/pom.xml
@@ -19,7 +19,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-aws</artifactId>
+      <artifactId>camel-aws-s3</artifactId>
     </dependency>
     <!-- logging -->
     <dependency>

--- a/advanced/camel-k/splitter/src/main/java/com/example/camel/DownloadAndSplit.java
+++ b/advanced/camel-k/splitter/src/main/java/com/example/camel/DownloadAndSplit.java
@@ -92,7 +92,7 @@ public class DownloadAndSplit extends RouteBuilder {
             if (System.getenv().containsKey(key)) {
                 return System.getenv().getOrDefault(key, defaultValue);
             } else {
-                return propertiesComponent.parseUri(propertiesComponent.getPrefixToken() + key + propertiesComponent.getSuffixToken());
+                return propertiesComponent.parseUri(PropertiesComponent.PREFIX_TOKEN + key + PropertiesComponent.SUFFIX_TOKEN);
             }
         } catch (IllegalArgumentException e) {
             return defaultValue;

--- a/advanced/camel-k/splitter/src/main/java/com/example/camel/DownloadAndSplit.java
+++ b/advanced/camel-k/splitter/src/main/java/com/example/camel/DownloadAndSplit.java
@@ -13,7 +13,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.amqp.AMQPComponent;
 import org.apache.camel.component.aws.s3.S3Component;
 import org.apache.camel.component.properties.PropertiesComponent;
-import org.apache.camel.processor.idempotent.MemoryIdempotentRepository;
+import org.apache.camel.support.processor.idempotent.MemoryIdempotentRepository;
 import org.apache.camel.spi.IdempotentRepository;
 import org.apache.qpid.jms.JmsConnectionFactory;
 


### PR DESCRIPTION
With these changes the updates the Maven build in the advanced/camel-k completes successfully, although I am not sure the changes are correct. There are also still some warnings about usages of deprecated methods. Unfortunately I haven't been able to test the examples, because the examples don't start (although the build of the integration kits seem to complete without errors). Maybe it's just some problem in my environment (minikube 1.4.0 with k8s 1.16.0 on Ubuntu 18.04 using the none driver; this runs in a VirtualBox VM on Windows 10 Pro).