### PR TITLE
update curler to fedora:34

### DIFF
--- a/eventing/curler.yaml
+++ b/eventing/curler.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   containers:
     - name: curler
-      image: fedora:29 
+      image: fedora:34
       tty: true


### PR DESCRIPTION
fedora 29 is EOL (and the tag is no longer present in the fedora registry), use current fedora image