### PR TITLE
Update kn service command for the scale-min configuration

### DIFF
--- a/documentation/modules/serving/pages/_partials/deploy-knative-resources.adoc
+++ b/documentation/modules/serving/pages/_partials/deploy-knative-resources.adoc
@@ -80,7 +80,7 @@ kn service create prime-generator \
 [.console-input]
 [source,bash,subs="+macros,+attributes"]
 ----
-kn service update prime-generator \
+kn service create prime-generator \
   --concurrency-target=10 \
   --scale-min=2 \
   --image=quay.io/rhdevelopers/prime-generator:v27-quarkus


### PR DESCRIPTION
The kn command for the service should be a `create` one instead of an `update` one as we require the reader to delete the resource in the preceding section (https://redhat-developer-demos.github.io/knative-tutorial/knative-tutorial/serving/scaling.html#scaling-load-service)

`For more clarity and understanding let us [clean up](https://redhat-developer-demos.github.io/knative-tutorial/knative-tutorial/serving/scaling.html#scaling-cleanup) existing deployments before proceeding to next section.`

Either we have to remove this sentence or we should use `create` for the command I proposed. Here is the relevant page: https://redhat-developer-demos.github.io/knative-tutorial/knative-tutorial/serving/scaling.html#scaling-min-scale

