### PR TITLE
Fix apiVersion for timed-greeter Kamelet camel-k example

### DIFF
--- a/documentation/modules/camelk/pages/camel-k-eventing.adoc
+++ b/documentation/modules/camelk/pages/camel-k-eventing.adoc
@@ -136,7 +136,7 @@ The following listing provides the details of Kamelet configuration:
 .timed-greeter Kamelet
 [source,yaml]
 ----
-apiVersion: sources.knative.dev/v1alpha1 #<1>
+apiVersion: camel.apache.org/v1alpha1 #<1>
 kind: Kamelet
 metadata:
   name: timed-greeter


### PR DESCRIPTION
:broom: Fix apiVersion for timed-greeter Kamelet camel-k example

Page code example diverges from actual repo code example (working version)